### PR TITLE
Added Shellout files on the Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Master
 
+* Added Shellout files on the Makefile [#91](https://github.com/danger/danger-swift/pull/91) by [f-meloni](https://github.com/f-meloni)
 * Restored danger-swift edit functionality - [#90](https://github.com/danger/danger-swift/pull/90) by [f-meloni](https://github.com/f-meloni)
 * Expose Danger report results - [#89](https://github.com/danger/danger-swift/pull/89) by [f-meloni](https://github.com/f-meloni)
 - Adds two new commands: 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_PATH = .build/release/$(TOOL_NAME)
 LIB_INSTALL_PATH = $(PREFIX)/lib/danger
 TAR_FILENAME = $(TOOL_NAME)-$(VERSION).tar.gz
 
-SWIFT_LIB_FILES = .build/release/libDanger.* .build/release/Danger.swiftdoc .build/release/Danger.swiftmodule
+SWIFT_LIB_FILES = .build/release/libDanger.* .build/release/Danger.swiftdoc .build/release/Danger.swiftmodule .build/release/ShellOut.swiftmodule .build/release/ShellOut.swiftdoc
 
 install: build
 	mkdir -p $(PREFIX)/bin


### PR DESCRIPTION
If you try to run `danger-swift pr $PR` and you are using the installed `swift-danger` (then you don't full `.build` folder) you get this error.

```sh
Danger: ⅹ Failing the build, there is 1 fail.

Dangerfile.swift:4:8: error: missing required module 'ShellOut'
import Danger
       ^
```

Not sure this is the best solution to the problem, but adding this and calling `make install` solved the problem in my case.