### PR TITLE
Improve danger swift edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Master
 
+* Improve danger-swift edit [#94](https://github.com/danger/danger-swift/pull/94) by [f-meloni](https://github.com/f-meloni)
 * Ability to import files on the Dangerfile [#93](https://github.com/danger/danger-swift/pull/93) by [f-meloni](https://github.com/f-meloni)
 * Added Shellout files on the Makefile [#91](https://github.com/danger/danger-swift/pull/91) by [f-meloni](https://github.com/f-meloni)
 * Restored danger-swift edit functionality - [#90](https://github.com/danger/danger-swift/pull/90) by [f-meloni](https://github.com/f-meloni)

--- a/DangerfileExtensions/ChangelogCheck.swift
+++ b/DangerfileExtensions/ChangelogCheck.swift
@@ -6,7 +6,7 @@ func checkChangelog() {
     let isTrivial = danger.github.pullRequest.title.contains("#trivial")
     
     if !isTrivial && !changelogChanged && sourceChanges != nil {
-        warn("""
+        danger.warn("""
      Any changes to library code should be reflected in the Changelog.
 
      Please consider adding a note there and adhere to the [Changelog Guidelines](https://github.com/Moya/contributors/blob/master/Changelog%20Guidelines.md).

--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -26,6 +26,12 @@ private final class DangerRunner {
         logger.logInfo("Ran with: \(CommandLine.arguments.joined(separator: " "))")
         
         let cliLength = CommandLine.arguments.count
+        
+        guard cliLength - 2 > 0 else {
+            logger.logError("To execute Danger run danger-swift ci , danger-swift pr or danger-swift local on your terminal")
+            exit(1)
+        }
+        
         let dslJSONArg: String? = CommandLine.arguments[cliLength - 2]
         let outputJSONPath = CommandLine.arguments[cliLength - 1]
 

--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -65,72 +65,142 @@ public func Danger() -> DangerDSL {
     return DangerRunner.shared.dsl
 }
 
+extension DangerDSL {
+    /// Fails on the Danger report
+    public var fails: [Violation] {
+        return DangerRunner.shared.results.fails
+    }
+    
+    /// Warnings on the Danger report
+    public var warnings: [Violation] {
+        return DangerRunner.shared.results.warnings
+    }
+    
+    /// Messages on the Danger report
+    public var messages: [Violation] {
+        return DangerRunner.shared.results.messages
+    }
+    
+    /// Markdowns on the Danger report
+    public var markdowns: [Violation] {
+        return DangerRunner.shared.results.markdowns
+    }
+    
+    /// Adds a warning message to the Danger report
+    ///
+    /// - Parameter message: A markdown-ish
+    public func warn(_ message: String) {
+        DangerRunner.shared.results.warnings.append(Violation(message: message))
+    }
+    
+    /// Adds an inline warning message to the Danger report
+    public func warn(message: String, file: String, line: Int) {
+        DangerRunner.shared.results.warnings.append(Violation(message: message, file: file, line: line))
+    }
+    
+    /// Adds a warning message to the Danger report
+    ///
+    /// - Parameter message: A markdown-ish
+    public func fail(_ message: String) {
+        DangerRunner.shared.results.fails.append(Violation(message: message))
+    }
+    
+    /// Adds an inline fail message to the Danger report
+    public func fail(message: String, file: String, line: Int) {
+        DangerRunner.shared.results.fails.append(Violation(message: message, file: file, line: line))
+    }
+    
+    /// Adds a warning message to the Danger report
+    ///
+    /// - Parameter message: A markdown-ish
+    public func message(_ message: String) {
+        DangerRunner.shared.results.messages.append(Violation(message: message))
+    }
+    
+    /// Adds an inline message to the Danger report
+    public func message(message: String, file: String, line: Int) {
+        DangerRunner.shared.results.messages.append(Violation(message: message, file: file, line: line))
+    }
+    
+    /// Adds a warning message to the Danger report
+    ///
+    /// - Parameter message: A markdown-ish
+    public func markdown(_ message: String) {
+        DangerRunner.shared.results.markdowns.append(Violation(message: message))
+    }
+    
+    /// Adds an inline message to the Danger report
+    public func markdown(message: String, file: String, line: Int) {
+        DangerRunner.shared.results.markdowns.append(Violation(message: message, file: file, line: line))
+    }
+}
+
 /// Fails on the Danger report
 public var fails: [Violation] {
-    return DangerRunner.shared.results.fails
+    return DangerRunner.shared.dsl.fails
 }
 
 /// Warnings on the Danger report
 public var warnings: [Violation] {
-    return DangerRunner.shared.results.warnings
+    return DangerRunner.shared.dsl.warnings
 }
 
 /// Messages on the Danger report
 public var messages: [Violation] {
-    return DangerRunner.shared.results.messages
+    return DangerRunner.shared.dsl.messages
 }
 
 /// Markdowns on the Danger report
 public var markdowns: [Violation] {
-    return DangerRunner.shared.results.markdowns
+    return DangerRunner.shared.dsl.markdowns
 }
 
 /// Adds a warning message to the Danger report
 ///
 /// - Parameter message: A markdown-ish
 public func warn(_ message: String) {
-    DangerRunner.shared.results.warnings.append(Violation(message: message))
+    DangerRunner.shared.dsl.warn(message)
 }
 
 /// Adds an inline warning message to the Danger report
 public func warn(message: String, file: String, line: Int) {
-    DangerRunner.shared.results.warnings.append(Violation(message: message, file: file, line: line))
+    DangerRunner.shared.dsl.warn(message: message, file: file, line: line)
 }
 
 /// Adds a warning message to the Danger report
 ///
 /// - Parameter message: A markdown-ish
 public func fail(_ message: String) {
-    DangerRunner.shared.results.fails.append(Violation(message: message))
+    DangerRunner.shared.dsl.fail(message)
 }
 
 /// Adds an inline fail message to the Danger report
 public func fail(message: String, file: String, line: Int) {
-    DangerRunner.shared.results.fails.append(Violation(message: message, file: file, line: line))
+    DangerRunner.shared.dsl.fail(message: message, file: file, line: line)
 }
 
 /// Adds a warning message to the Danger report
 ///
 /// - Parameter message: A markdown-ish
 public func message(_ message: String) {
-    DangerRunner.shared.results.messages.append(Violation(message: message))
+    DangerRunner.shared.dsl.message(message)
 }
 
 /// Adds an inline message to the Danger report
 public func message(message: String, file: String, line: Int) {
-    DangerRunner.shared.results.messages.append(Violation(message: message, file: file, line: line))
+    DangerRunner.shared.dsl.message(message: message, file: file, line: line)
 }
 
 /// Adds a warning message to the Danger report
 ///
 /// - Parameter message: A markdown-ish
 public func markdown(_ message: String) {
-    DangerRunner.shared.results.markdowns.append(Violation(message: message))
+    DangerRunner.shared.dsl.markdown(message)
 }
 
 /// Adds an inline message to the Danger report
 public func markdown(message: String, file: String, line: Int) {
-    DangerRunner.shared.results.markdowns.append(Violation(message: message, file: file, line: line))
+    DangerRunner.shared.dsl.markdown(message: message, file: file, line: line)
 }
 
 // MARK: - Private Functions

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -41,10 +41,12 @@ func editDanger(logger: Logger) throws -> Void {
     let scriptManager = try getScriptManager()
     let script = try scriptManager.script(atPath: dangerfilePath, allowRemote: true)
     
-    let xcodeprojPath = try script.setupForEdit(arguments: arguments, importedFiles: importedFiles)
-
-    // Amends the Xcodeproj to include our build paths
-    try addLibPathToXcodeProj(xcodeprojPath: xcodeprojPath, lib: absoluteLibPath)
+    let path = NSTemporaryDirectory()
+    let configPath = path + "config.xcconfig"
+    
+    try createConfig(atPath: configPath, lib: absoluteLibPath)
+    
+    try script.setupForEdit(arguments: arguments, importedFiles: importedFiles, configPath: configPath)
 
     try script.watch(arguments: arguments, importedFiles: importedFiles)
 }

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -30,8 +30,7 @@ func runDanger(logger: Logger) throws -> Void {
         exit(1)
     }
     logger.logInfo("Running Dangerfile at: \(dangerfilePath)")
-
-
+    
     guard let libDangerPath = Runtime.getLibDangerPath() else {
         let potentialFolders = Runtime.potentialLibraryFolders
         logger.logError("Could not find a libDanger to link against at any of: \(potentialFolders)",

--- a/Sources/Runner/EditXcodeProj.swift
+++ b/Sources/Runner/EditXcodeProj.swift
@@ -1,27 +1,14 @@
 import Foundation
 import Files
 
-/// Before:
-///    OTHER_SWIFT_FLAGS = (
-///        "-DXcode",
-///    );
-///
-/// After:
-///    OTHER_SWIFT_FLAGS = (
-///        "-I",
-///        "/Users/orta/dev/projects/danger/danger-swift/.build/debug",
-///        "-L",
-///        "/Users/orta/dev/projects/danger/danger-swift/.build/debug",
-///        "-DXcode",
-///    );
-///
 
-func addLibPathToXcodeProj(xcodeprojPath: String, lib: String) throws -> Void {
-    let pbxproj = try File(path: xcodeprojPath  + "project.pbxproj")
-    let content = try pbxproj.readAsString()
-    let before = "-DXcode\","
-    let after = "-DXcode\", \"-I\", \"\(lib)\", \"-L\", \"\(lib)\""
-    let newContent = content.replacingOccurrences(of: before, with: after)
-
-    try pbxproj.write(string:newContent)
+// Creates an xcconfig file that can be used to correctly link danger library to the xcodeproj
+func createConfig(atPath configPath: String, lib: String) throws -> Void {
+    let config = """
+    LIBRARY_SEARCH_PATHS = \(lib)
+    OTHER_SWIFT_FLAGS = -DXcode -I \(lib) -L \(lib)
+    OTHER_LDFLAGS = -l danger
+    """
+    
+    try config.write(toFile: configPath, atomically: false, encoding: .utf8)
 }


### PR DESCRIPTION
This might be a little bit controversial in some points, i will try to put as much as possible details, images and inline comments about what i'm trying to do

## PR Goal

<img width="834" alt="screenshot 2018-11-05 at 19 43 40" src="https://user-images.githubusercontent.com/17830956/48023531-fd0ffd80-e135-11e8-8758-0c565b707f1a.png">

If you run `danger-swift edit` you will see that, with no syntax highlighting, no auto competition.
The reason for that was that it was not correctly overriding the `OTHER_SWIFT_FLAGS`.
But once i did override them correctly (was enough remove the `,` `let before = "-DXcode\","` to fix that) the syntax highlighting was correct, but it was not compiling.
In order to make it compile i had to link the danger library, this is why i though that was a good idea to actually use the `--xcconfig-overrides` option on the `generate-xcodeproj` command

This is the result

<img width="959" alt="screenshot 2018-11-05 at 19 46 59" src="https://user-images.githubusercontent.com/17830956/48023781-a48d3000-e136-11e8-8ff3-a784ea738c33.png">