### PR TITLE
Allow swift run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,32 @@
 <!--
 
 // Please add your own contribution below inside the Master section, no need to
-// set a version number, that happens during a deploy.
+// set a version number, that happens during a deploy. Thanks!
 //
 // These docs are aimed at users rather than danger developers, so please limit technical
 // terminology in here.
+
+// Note: if this is your first PR, you'll need to add your URL to the footnotes
+//       see the bottom of this file
 
 -->
 
 ## Master
 
-* Add Github API client [#95](https://github.com/danger/danger-swift/pull/95) by [f-meloni](https://github.com/f-meloni)
-* Improve danger-swift edit [#94](https://github.com/danger/danger-swift/pull/94) by [f-meloni](https://github.com/f-meloni)
-* Ability to import files on the Dangerfile [#93](https://github.com/danger/danger-swift/pull/93) by [f-meloni](https://github.com/f-meloni)
-* Added Shellout files on the Makefile [#91](https://github.com/danger/danger-swift/pull/91) by [f-meloni](https://github.com/f-meloni)
-* Restored danger-swift edit functionality - [#90](https://github.com/danger/danger-swift/pull/90) by [f-meloni](https://github.com/f-meloni)
-* Expose Danger report results - [#89](https://github.com/danger/danger-swift/pull/89) by [f-meloni](https://github.com/f-meloni)
-- Adds two new commands: 
-    - `danger-swift ci` - handles running Danger
-    - `danger-swift pr [https://github.com/Moya/Harvey/pull/23]` - Let's you run Danger against a PR locally
+* Add Github API client [#95](https://github.com/danger/danger-swift/pull/95) by [@f-meloni][]
+* Improve danger-swift edit [#94](https://github.com/danger/danger-swift/pull/94) by [@f-meloni][]
+* Ability to import files on the Dangerfile [#93](https://github.com/danger/danger-swift/pull/93) by [@f-meloni][]
+* Added Shellout files on the Makefile [#91](https://github.com/danger/danger-swift/pull/91) by [@f-meloni][]
+* Restored danger-swift edit functionality - [#90](https://github.com/danger/danger-swift/pull/90) by [@f-meloni][]
+* Expose Danger report results - [#89](https://github.com/danger/danger-swift/pull/89) by [@f-meloni][]
 
-* Prepares for Danger JS 5.0 - [#84](https://github.com/danger/danger-swift/pull/84) by [orta](https://github.com/orta)
+- Adds three new commands: 
+    - `danger-swift ci` - handles running Danger
+    - `danger-swift pr [https://github.com/Moya/Harvey/pull/23]` - Let's you run Danger against a PR for local dev
+    - `danger-swift local - Let's you run Danger against the diff from your branch to master
+
+* Prepares for Danger JS 5.0 - [#84](https://github.com/danger/danger-swift/pull/84) by [@orta][]
+* When working on danger, you cna now use `swift run danger-swift xx` to try commands - [@orta][]
 
 ## 0.4.1
 
@@ -68,8 +74,8 @@
 
 ## 0.3.0
 
-* Supports the command: `danger-swift edit` to generate an Xcodeproj which you can edit your Dangerfile in - orta
-* Adds plugin infrastructure to `danger-swift` - orta
+* Supports the command: `danger-swift edit` to generate an Xcodeproj which you can edit your Dangerfile in - [@orta][]
+* Adds plugin infrastructure to `danger-swift` - [@orta][]
 
   There aren't any plugins yet, but there is infrastructure for them. By suffixing `package: [url]` to any import, you
   can directly import Swift PM package as a dependency, which is basically how plugins will work.
@@ -84,11 +90,11 @@
 
 ## 0.2.0
 
-* Support the beta formatting of the JSON DSL ( it now is `{ "danger": { [DSL] }}`, instead of a root element) - orta
+* Support the beta formatting of the JSON DSL ( it now is `{ "danger": { [DSL] }}`, instead of a root element) - [@orta][]
 
 ## 0.1.1
 
-* Fix install paths for libDanger when using homebrew - orta
+* Fix install paths for libDanger when using homebrew - [@orta][]
 
 ## 0.1.0
 
@@ -97,9 +103,13 @@
 ## 0.0.2
 
 * Supports a Dangerfile in both: "/Dangerfile.swift", "/danger/Dangerfile.swift" or "/Danger/Dangerfile.swift" to handle
-  SPM rules on Swift files in the root - orta
-* Adds a CHANGELOG, renames project to danger-swift - orta
+  SPM rules on Swift files in the root - [@orta][]
+* Adds a CHANGELOG, renames project to danger-swift - [@orta][]
 
 ## 0.0.1
 
-* Initialish versions - orta, SD10
+* Initialish versions - [@orta][], SD10
+
+
+[@f-meloni]: https://github.com/f-meloni
+[@orta]: https://github.com/orta

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -8,6 +8,8 @@ let danger = Danger()
 // fileImport: DangerfileExtensions/ChangelogCheck.swift
 checkChangelog()
 
+print("Hi from the runtime")
+
 if (danger.git.createdFiles.count + danger.git.modifiedFiles.count - danger.git.deletedFiles.count > 10) {
     warn("Big PR, try to keep changes smaller if you can")
 }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -18,7 +18,9 @@ if danger.github.pullRequest.title.contains("WIP") {
     warn("PR is classed as Work in Progress")
 }
 
+print("HI")
 _ = danger.github.api.me { response in
+    print("OK")
     switch response {
     case .success(let user):
         message(user.name ?? "")

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ swift package generate-xcodeproj
 open Danger.xcodeproj
 ```
 
-Then I tend to run it by eval the Dangerfile with:
+Then I tend to run it by eval-ing the Dangerfile with:
 
 ```sh
 swift build && swiftc --driver-mode=swift -L .build/debug -I .build/debug -lDanger Dangerfile.swift fixtures/eidolon_609.json fixtures/response_data.json

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Xcode project set up for editing a Swift Dangerfile.
 
 ### Commands
 
-- `danger-swift ci` - Is the command for running on CI
-- `danger-swift pr https://github.com/Moya/Harvey/pull/23` - Is the command for running a PR locally
+- `danger-swift ci` - Use this on CI
+- `danger-swift pr https://github.com/Moya/Harvey/pull/23` - Use thi9s to build your Dangerfile
+- `danger-swift local - Use this to run danger against your local changes from master
 - `danger-swift edit` - Creates a temporary Xcode project for working on a Dangerfile
 
 #### Plugins
@@ -135,10 +136,10 @@ swift package generate-xcodeproj
 open Danger.xcodeproj
 ```
 
-Then I tend to run it by eval-ing the Dangerfile with:
+Then I tend to run `danger-swift` using `swift run`:
 
 ```sh
-swift build && swiftc --driver-mode=swift -L .build/debug -I .build/debug -lDanger Dangerfile.swift fixtures/eidolon_609.json fixtures/response_data.json
+swift run danger-swift pr https://github.com/danger/swift/pull/95
 ```
 
 If you want to emulate how DangerJS's `process` will work entirely, then use:

--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -23,7 +23,7 @@ private final class DangerRunner {
         let isVerbose = CommandLine.arguments.contains("--verbose") || (ProcessInfo.processInfo.environment["DEBUG"] != nil)
         let isSilent = CommandLine.arguments.contains("--silent")
         logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
-        logger.logInfo("Ran with: \(CommandLine.arguments.joined(separator: " "))")
+        logger.debug("Ran with: \(CommandLine.arguments.joined(separator: " "))")
         
         let cliLength = CommandLine.arguments.count
         
@@ -46,7 +46,7 @@ private final class DangerRunner {
         }
         do {
             let string = String(data: dslJSONContents, encoding: .utf8)
-            logger.logInfo(string!, isVerbose: true)
+            logger.debug(string!)
 
             let decoder = JSONDecoder()
             if #available(OSX 10.12, *) {
@@ -216,7 +216,7 @@ private var dumpInfo: (danger: DangerRunner, path: String)?
 private func dumpResultsAtExit(_ runner: DangerRunner, path: String) {
     func dump() {
         guard let dumpInfo = dumpInfo else { return }
-        dumpInfo.danger.logger.logInfo("Sending results back to Danger")
+        dumpInfo.danger.logger.debug("Sending results back to Danger")
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = .prettyPrinted

--- a/Sources/Danger/Logger.swift
+++ b/Sources/Danger/Logger.swift
@@ -16,6 +16,11 @@ public struct Logger {
         self.isSilent = isSilent
     }
 
+    public func debug(_ items: Any..., separator: String = " ", terminator: String = "\n", isVerbose: Bool = true) {
+        let message = items.joinedDescription(separator: separator)
+        print(message, terminator: terminator, isVerbose: isVerbose)
+    }
+
     public func logInfo(_ items: Any..., separator: String = " ", terminator: String = "\n", isVerbose: Bool = false) {
         let message = items.joinedDescription(separator: separator)
         print(message, terminator: terminator, isVerbose: isVerbose)

--- a/Sources/Danger/Runtime.swift
+++ b/Sources/Danger/Runtime.swift
@@ -46,6 +46,13 @@ public struct Runtime {
                 fileManager.fileExists(atPath: path + "/libDanger.so")        // Linux
         }
 
-        return libPaths.first(where: isTheDangerLibPath)
+        guard let path = libPaths.first(where: isTheDangerLibPath) else { return nil }
+
+        // Always return an absolute path
+        if path.starts(with: "/") {
+            return path
+        }
+
+        return fileManager.currentDirectoryPath + "/" + path
     }
 }

--- a/Sources/Danger/getDangerJSPath.swift
+++ b/Sources/Danger/getDangerJSPath.swift
@@ -2,6 +2,6 @@ import Foundation
 import ShellOut
 
 public func getDangerJSPath(_ logger: Logger) throws -> String {
-    logger.logInfo("Finding out where the danger executable is")
+    logger.debug("Finding out where the danger executable is")
     return try shellOut(to: "which danger").trimmingCharacters(in: .whitespaces)
 }

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -38,7 +38,7 @@ func editDanger(logger: Logger) throws -> Void {
     let absoluteLibPath = try Folder(path: libPath).path
 
     let arguments = CommandLine.arguments
-    let scriptManager = try getScriptManager()
+    let scriptManager = try getScriptManager(logger)
     let script = try scriptManager.script(atPath: dangerfilePath, allowRemote: true)
     
     let path = NSTemporaryDirectory()

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -9,15 +9,23 @@ func runDangerJSCommandToRunDangerSwift(_ command: String, logger: Logger) throw
     proc.launchPath = dangerJS
 
     let unusedArgs = CommandLine.arguments.filter { arg in
-        arg != "danger-swift" && arg != command
+        !arg.contains("danger-swift") && arg != command
     }
-    proc.arguments =  [ command, "--process", "danger-swift" ] + unusedArgs
+
+    var dangerSwiftCommand = "danger-swift"
+    // Special-case running inside the danger dev dir
+    let fileManager = FileManager.default
+    if fileManager.fileExists(atPath: ".build/debug/danger-swift") {
+        dangerSwiftCommand = ".build/debug/danger-swift"
+    }
+
+    proc.arguments =  [ command, "--process", dangerSwiftCommand ] + unusedArgs
 
     let standardOutput = FileHandle.standardOutput
     proc.standardOutput = standardOutput
     proc.standardError = standardOutput
 
-    logger.logInfo("Running: \(proc.launchPath!) \(proc.arguments!.joined(separator: " ")) ")
+    logger.debug("Running: \(proc.launchPath!) \(proc.arguments!.joined(separator: " ")) ")
     proc.launch()
     proc.waitUntilExit()
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -55,7 +55,7 @@ func runDanger(logger: Logger) throws -> Void {
         try tempDangerfile.write(string: importExternalDeps.joined(separator: "\n"))
         defer { try? tempDangerfile.delete() }
 
-        let scriptManager = try getScriptManager()
+        let scriptManager = try getScriptManager(logger)
         let script = try scriptManager.script(atPath: tempDangerfile.path, allowRemote: true)
 
         try script.build()

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -19,7 +19,7 @@ func runDanger(logger: Logger) throws -> Void {
         logger.logError("Could not create a temporary file for the Dangerfile DSL at: \(dslJSONPath)")
         exit(1)
     }
-    logger.logInfo("Created a temporary file for the Dangerfile DSL at: \(dslJSONPath)")
+    logger.debug("Created a temporary file for the Dangerfile DSL at: \(dslJSONPath)")
 
 
     // Exit if a dangerfile was not found at any supported path
@@ -29,7 +29,7 @@ func runDanger(logger: Logger) throws -> Void {
                         separator: "\n")
         exit(1)
     }
-    logger.logInfo("Running Dangerfile at: \(dangerfilePath)")
+    logger.debug("Running Dangerfile at: \(dangerfilePath)")
     
     guard let libDangerPath = Runtime.getLibDangerPath() else {
         let potentialFolders = Runtime.potentialLibraryFolders
@@ -48,7 +48,7 @@ func runDanger(logger: Logger) throws -> Void {
     let importExternalDeps = importsOnly.components(separatedBy: .newlines).filter { $0.hasPrefix("import") && $0.contains("package: ") }
 
     if (importExternalDeps.count > 0) {
-        logger.logInfo("Getting inline dependencies: \(importExternalDeps.joined(separator: ", "))")
+        logger.debug("Getting inline dependencies: \(importExternalDeps.joined(separator: ", "))")
 
         try Folder(path: ".").createFileIfNeeded(withName: "_dangerfile_imports.swift")
         let tempDangerfile = try File(path: "_dangerfile_imports.swift")
@@ -103,7 +103,7 @@ func runDanger(logger: Logger) throws -> Void {
     let swiftCPath = supportedSwiftCPaths.first { fileManager.fileExists(atPath: $0) }
     let swiftC = swiftCPath ?? "swiftc"
 
-    logger.logInfo("Running: \(swiftC) \(args.joined(separator: " "))")
+    logger.debug("Running: \(swiftC) \(args.joined(separator: " "))")
 
     // Create a process to eval the Swift file
     let proc = Process()
@@ -117,7 +117,7 @@ func runDanger(logger: Logger) throws -> Void {
     proc.launch()
     proc.waitUntilExit()
 
-    logger.logInfo("Completed evaluation")
+    logger.debug("Completed evaluation")
 
     if (proc.terminationStatus != 0) {
         logger.logError("Dangerfile eval failed at \(dangerfilePath)")
@@ -135,7 +135,7 @@ func runDanger(logger: Logger) throws -> Void {
 
     // Support the upcoming danger results-url
     standardOutput.write("danger-results:/\(dangerResponsePath)".data(using: .utf8)!)
-    logger.logInfo("Saving and storing the results at \(dangerResponsePath)")
+    logger.debug("Saving and storing the results at \(dangerResponsePath)")
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)

--- a/Sources/Runner/MarathonScriptManager.swift
+++ b/Sources/Runner/MarathonScriptManager.swift
@@ -1,11 +1,14 @@
 import Files
+import Danger
 import MarathonCore
 
-func getScriptManager() throws -> ScriptManager {
+func getScriptManager(_ logger: Logger) throws -> ScriptManager {
+    
     let folder = "~/.danger-swift"
     let printFunction = { print($0) }
+
     let vPrintFunction = { (messageExpression: () -> String) in
-        print(messageExpression())
+        logger.debug(messageExpression())
     }
     
     let printer = Printer(

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -8,13 +8,15 @@ do {
     let logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
 
     if cliLength > 1 {
-        logger.logInfo("Launching Danger Swift \(CommandLine.arguments[1]) (v\(DangerVersion))")
+        logger.debug("Launching Danger Swift \(CommandLine.arguments[1]) (v\(DangerVersion))")
         switch(CommandLine.arguments[1]) {
         case "ci", "local", "pr":
             let exitCode = try runDangerJSCommandToRunDangerSwift(CommandLine.arguments[1], logger: logger)
             exit(exitCode)
         case "edit":
             try editDanger(logger: logger)
+        case "runner":
+            try runDanger(logger: logger)
         default:
             fatalError("Danger Swift does not support this argument, it only handles ci, local, pr & edit'")
         }


### PR DESCRIPTION
This PR adds adds some docs, ensure that danger-swift can run via `run swift` and hides a lot of the default logging behind the debug/verbose flags.