### PR TITLE
Make sure there is an EOL when sending a message back to danger-js

### DIFF
--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -143,7 +143,7 @@ func runDanger(logger: Logger) throws -> Void {
     }
 
     // Support the upcoming danger results-url
-    standardOutput.write("danger-results:/\(dangerResponsePath)".data(using: .utf8)!)
+    standardOutput.write("danger-results:/\(dangerResponsePath)\n\n".data(using: .utf8)!)
     logger.debug("Saving and storing the results at \(dangerResponsePath)")
 
     // Clean up after ourselves


### PR DESCRIPTION
From https://travis-ci.org/danger/swift/jobs/458490270

```sh
  danger:runDangerSubprocess Got JSON URL from STDOUT, results are at: 
  danger:runDangerSubprocess danger-results://var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-response.jsonCreated a temporary file for the Dangerfile DSL at: /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-dsl.json +41s
Error:  Error: Process '' reported that its JSON results could be found at /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-response.jsonCreated a temporary file for the Dangerfile DSL at: /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-dsl.json, but the file was missing. The STDOUT was: danger-results://var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-response.jsonCreated a temporary file for the Dangerfile DSL at: /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/danger-dsl.json
```