### PR TITLE
Don't send the command again to danger-js

### DIFF
--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -20,7 +20,7 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
         dangerSwiftCommand = ".build/debug/danger-swift"
     }
 
-    proc.arguments = [command.rawValue, "--process", dangerSwiftCommand, "--passURLForDSL"] + unusedArgs
+    proc.arguments = ["--process", dangerSwiftCommand, "--passURLForDSL"] + unusedArgs
 
     let standardOutput = FileHandle.standardOutput
     proc.standardOutput = standardOutput


### PR DESCRIPTION
Currently we are sending the same command two times to danger-js 

e.g.
```
danger-pr pr --process danger-swift PRLink
```