### PR TITLE
Remove additional build on travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
       install:
         - node -v
         - npm install -g danger
-        - swift build
         - make install
       script:
         - swift test
@@ -35,7 +34,6 @@ matrix:
         - npm install -g danger
         - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
         - swiftenv global 4.2
-        - swift build
       script:
         - swift test
         - sudo chmod -R a+rwx /usr/local/


### PR DESCRIPTION
During the CI danger swift is already builded for test by `swift test` and builded again (for release) from `make install`, then i think we can save some time by avoid building it again with swift build