### PR TITLE
Merges in Danger SwiftLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,22 @@
 
 ## Master
 
+- Whoah! The SwiftLint plugin has been merged into Danger by [@orta][]
+
+  This is not my work, really, it's the work of the contributors to the Danger SwiftLint plugin (which, yes, I am a
+  contributor, so...) - but it's mainly the work of [@ashfurrow][] [@sunshinejr][] [@Killectro][] and [@thii][].
+
+  This is discussed in https://github.com/ashfurrow/danger-swiftlint/issues/17 where I pitched that maybe we should just
+  inline this dependency because so many people are going to use this. The Swift community is likely the only community
+  using Danger Swift, so why not make this version have a bit more focus on what people are doing with it?
+
 - Docs, lots of lots of docs by [@orta][]
+
+  This is a blocker on 1.0ing Danger Swift. So, we're getting there now.
+
 - Internal faffing, and splitting of some test-related code so that Plugins can have an elegant test API by [@orta][]
+
+  This revises the way in which you can write tests in Danger plugins. Should be much easier now.
 
 ## 0.7.3
 
@@ -151,3 +165,7 @@
 
 [@f-meloni]: https://github.com/f-meloni
 [@orta]: https://github.com/orta
+[@ashfurrow]: https://github.com/ashfurrow
+[@sunshinejr]: https://github.com/sunshinejr
+[@killectro]: https://github.com/Killectro
+[@thii]: https://github.com/thii

--- a/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
+++ b/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+internal protocol CurrentPathProvider {
+    var currentPath: String { get }
+}
+
+internal final class DefaultCurrentPathProvider: CurrentPathProvider {
+    var currentPath: String {
+        return ShellExecutor().execute("pwd")
+    }
+}

--- a/Sources/Danger/Plugins/SwiftLint/ShellExecutor.swift
+++ b/Sources/Danger/Plugins/SwiftLint/ShellExecutor.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// TODO: Move to ShellOut?
+// import ShellOut
+
+internal class ShellExecutor {
+    func execute(_ command: String, arguments: [String] = []) -> String {
+        let script = "\(command) \(arguments.joined(separator: " "))"
+        print("Executing \(script)")
+
+        var env = ProcessInfo.processInfo.environment
+        let task = Process()
+        task.launchPath = env["SHELL"]
+        task.arguments = ["-l", "-c", script]
+        task.currentDirectoryPath = FileManager.default.currentDirectoryPath
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.launch()
+        task.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: String.Encoding.utf8)!
+    }
+}

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -1,0 +1,118 @@
+import Foundation
+import ShellOut
+
+/// The SwiftLint plugin has been embedded inside Danger, making
+/// it usable out of the box.
+public struct SwiftLint {
+    internal static let danger = Danger()
+    internal static let shellExecutor = ShellExecutor()
+
+    /// This is the main entry point for linting Swift in PRs using Danger-Swift.
+    /// Call this function anywhere from within your Dangerfile.swift.
+    @discardableResult
+    public static func lint(inline: Bool = false, directory: String? = nil,
+                            configFile: String? = nil, lintAllFiles: Bool = false,
+                            swiftlintPath: String = "swiftlint") -> [SwiftLintViolation] {
+        return lint(danger: danger, shellExecutor: shellExecutor, inline: inline, directory: directory,
+                    configFile: configFile, lintAllFiles: lintAllFiles, swiftlintPath: swiftlintPath)
+    }
+}
+
+/// This extension is for internal workings of the plugin. It is marked as internal for unit testing.
+internal extension SwiftLint {
+    static func lint(
+        danger: DangerDSL,
+        shellExecutor: ShellExecutor,
+        inline: Bool = false,
+        directory: String? = nil,
+        configFile: String? = nil,
+        lintAllFiles: Bool = false,
+        swiftlintPath: String = "swiftlint",
+        currentPathProvider: CurrentPathProvider = DefaultCurrentPathProvider(),
+        markdownAction: (String) -> Void = markdown,
+        failAction: (String) -> Void = fail,
+        failInlineAction: (String, String, Int) -> Void = fail,
+        warnInlineAction: (String, String, Int) -> Void = warn
+    ) -> [SwiftLintViolation] {
+        var violations: [SwiftLintViolation]
+
+        if lintAllFiles {
+            // Allow folks to lint all the potential files
+            var arguments = ["lint", "--quiet", "--reporter json"]
+            if let directory = directory {
+                arguments.append("--path \"\(directory)\"")
+            }
+            if let configFile = configFile {
+                arguments.append("--config \"\(configFile)\"")
+            }
+            let outputJSON = shellExecutor.execute(swiftlintPath, arguments: arguments)
+            violations = makeViolations(from: outputJSON, failAction: failAction)
+
+        } else {
+            // Gathers modified+created files, invokes SwiftLint on each, and posts collected errors+warnings to Danger.
+            var files = danger.git.createdFiles + danger.git.modifiedFiles
+            if let directory = directory {
+                files = files.filter { $0.hasPrefix(directory) }
+            }
+
+            violations = files.filter { $0.hasSuffix(".swift") }.flatMap { file -> [SwiftLintViolation] in
+                var arguments = ["lint", "--quiet", "--path \"\(file)\"", "--reporter json"]
+                if let configFile = configFile {
+                    arguments.append("--config \"\(configFile)\"")
+                }
+                let outputJSON = shellExecutor.execute(swiftlintPath, arguments: arguments)
+                return makeViolations(from: outputJSON, failAction: failAction)
+            }
+        }
+
+        let currentPath = currentPathProvider.currentPath
+        violations = violations.map { violation in
+            let updatedPath = violation.file.deletingPrefix(currentPath).deletingPrefix("/")
+            var violation = violation
+            violation.update(file: updatedPath)
+            return violation
+        }
+
+        if !violations.isEmpty {
+            if inline {
+                violations.forEach { violation in
+                    switch violation.severity {
+                    case .error:
+                        failInlineAction(violation.reason, violation.file, violation.line)
+                    case .warning:
+                        warnInlineAction(violation.reason, violation.file, violation.line)
+                    }
+                }
+            } else {
+                var markdownMessage = """
+                ### SwiftLint found issues
+
+                | Severity | File | Reason |
+                | -------- | ---- | ------ |\n
+                """
+                markdownMessage += violations.map { $0.toMarkdown() }.joined(separator: "\n")
+                markdownAction(markdownMessage)
+            }
+        }
+
+        return violations
+    }
+
+    private static func makeViolations(from response: String, failAction: (String) -> Void) -> [SwiftLintViolation] {
+        let decoder = JSONDecoder()
+        do {
+            let violations = try decoder.decode([SwiftLintViolation].self, from: response.data(using: .utf8)!)
+            return violations
+        } catch {
+            failAction("Error deserializing SwiftLint JSON response (\(response)): \(error)")
+            return []
+        }
+    }
+}
+
+private extension String {
+    func deletingPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return self }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
@@ -1,0 +1,50 @@
+public struct SwiftLintViolation: Codable {
+    enum Severity: String, Codable {
+        case warning = "Warning"
+        case error = "Error"
+    }
+
+    let ruleID: String
+    let reason: String
+    let line: Int
+    let character: Int?
+    let severity: Severity
+    let type: String
+
+    private(set) var file: String
+
+    enum CodingKeys: String, CodingKey {
+        case ruleID = "rule_id"
+        case reason, line, character, file, severity, type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        ruleID = try values.decode(String.self, forKey: .ruleID)
+        reason = try values.decode(String.self, forKey: .reason)
+        line = try values.decode(Int.self, forKey: .line)
+        character = try values.decode(Int?.self, forKey: .character)
+        file = try values.decode(String.self, forKey: .file)
+        severity = try values.decode(Severity.self, forKey: .severity)
+        type = try values.decode(String.self, forKey: .type)
+    }
+
+    public func toMarkdown() -> String {
+        let formattedFile = file.split(separator: "/").last! + ":\(line)"
+        return "\(severity.rawValue) | \(formattedFile) | \(reason) |"
+    }
+
+    mutating func update(file: String) {
+        self.file = file
+    }
+}
+
+/*
+ "rule_id" : "opening_brace",
+ "reason" : "Opening braces should be preceded by a single space and on the same line as the declaration.",
+ "character" : 39,
+ "file" : "\/Users\/ash\/bin\/Harvey\/Sources\/Harvey\/Harvey.swift",
+ "severity" : "Warning",
+ "type" : "Opening Brace Spacing",
+ "line" : 8
+ */

--- a/Sources/DangerFixtures/DangerFixtures.swift
+++ b/Sources/DangerFixtures/DangerFixtures.swift
@@ -35,7 +35,7 @@ public let githubFixtureDSL = parseDangerDSL(with: DSLGitHubJSON)
 public let githubEnterpriseFixtureDSL = parseDangerDSL(with: DSLGitHubEnterpriseJSON)
 /// An example DSL using BitBucket
 public let bitbucketFixtureDSL = parseDangerDSL(with: DSLBitBucketServerJSON)
-/// An example DSL using BitBucket
+/// An example DSL using GitHub
 public func githubWithFilesDSL(created: [File] = [], modified: [File] = [], deleted: [File] = [], fileMap: [String: String] = [:]) -> DangerDSL {
     return parseDangerDSL(with: githubJSONWithFiles(created: created, modified: modified, deleted: deleted, fileMap: fileMap))
 }

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -1,0 +1,194 @@
+@testable import Danger
+import DangerFixtures
+import XCTest
+
+class DangerSwiftLintTests: XCTestCase {
+    var executor: FakeShellExecutor!
+    var fakePathProvider: FakeCurrentPathProvider!
+    var danger: DangerDSL!
+    var markdownMessage: String?
+
+    override func setUp() {
+        executor = FakeShellExecutor()
+        fakePathProvider = FakeCurrentPathProvider()
+        fakePathProvider.currentPath = "/Users/ash/bin"
+
+        danger = githubFixtureDSL
+        markdownMessage = nil
+    }
+
+    func testExecutesTheShell() {
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        XCTAssertNotEqual(executor.invocations.dropFirst().count, 0)
+        XCTAssertEqual(executor.invocations.first?.command, "swiftlint")
+    }
+
+    func testExecutesTheShellWithCustomSwiftLintPath() {
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "Pods/SwiftLint/swiftlint", currentPathProvider: fakePathProvider)
+        XCTAssertNotEqual(executor.invocations.dropFirst().count, 0)
+        XCTAssertEqual(executor.invocations.first?.command, "Pods/SwiftLint/swiftlint")
+    }
+
+    func testExecuteSwiftLintInInlineMode() {
+        mockViolationJSON()
+        var warns = [(String, String, Int)]()
+        let warnAction: (String, String, Int) -> Void = { warns.append(($0, $1, $2)) }
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, inline: true, currentPathProvider: fakePathProvider, warnInlineAction: warnAction)
+
+        XCTAssertEqual(warns.first?.0, "Opening braces should be preceded by a single space and on the same line as the declaration.")
+        XCTAssertEqual(warns.first?.1, "SomeFile.swift")
+        XCTAssertEqual(warns.first?.2, 8)
+    }
+
+    func testExecutesSwiftLintWithConfigWhenPassed() {
+        let configFile = "/Path/to/config/.swiftlint.yml"
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, configFile: configFile, currentPathProvider: fakePathProvider)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+        XCTAssertTrue(swiftlintCommands.count > 0)
+        swiftlintCommands.forEach { _, arguments in
+            XCTAssertTrue(arguments.contains("--config \"\(configFile)\""))
+        }
+    }
+
+    func testExecutesSwiftLintWithDirectoryPassed() {
+        let directory = "Tests"
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "Test Dir/SomeThirdFile.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, directory: directory, currentPathProvider: fakePathProvider)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+        XCTAssertEqual(swiftlintCommands.count, 1)
+        XCTAssertTrue(swiftlintCommands.first!.arguments.contains("--path \"Tests/SomeFile.swift\""))
+    }
+
+    func testExecutesSwiftLintWhenLintingAllFiles() {
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "Test Dir/SomeThirdFile.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, lintAllFiles: true, currentPathProvider: fakePathProvider)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+        XCTAssertEqual(swiftlintCommands.count, 1)
+        XCTAssertFalse(swiftlintCommands.first!.arguments.contains("--path"))
+    }
+
+    func testExecutesSwiftLintWhenLintingAllFilesWithDirectoryPassed() {
+        let directory = "Tests"
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "Test Dir/SomeThirdFile.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, directory: directory, lintAllFiles: true, currentPathProvider: fakePathProvider)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+        XCTAssertEqual(swiftlintCommands.count, 1)
+        XCTAssertFalse(swiftlintCommands.first!.arguments.contains("--path \"Tests/SomeFile.swift\""))
+        XCTAssertTrue(swiftlintCommands.first!.arguments.contains("--path \"Tests\""))
+    }
+
+    func testFiltersOnSwiftFiles() {
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+
+        let quoteCharacterSet = CharacterSet(charactersIn: "\"")
+        let filesExtensions = Set(executor.invocations.dropFirst().compactMap { $0.arguments[2].split(separator: ".").last?.trimmingCharacters(in: quoteCharacterSet) })
+        XCTAssertEqual(filesExtensions, ["swift"])
+    }
+
+    func testPrintsNoMarkdownIfNoViolations() {
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        XCTAssertNil(markdownMessage)
+    }
+
+    func testViolations() {
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+        mockViolationJSON()
+
+        let violations = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
+        XCTAssertEqual(violations.count, 2) // Two files, one (identical oops) violation returned for each.
+    }
+
+    func testMarkdownReporting() {
+        mockViolationJSON()
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
+        XCTAssertNotNil(markdownMessage)
+        XCTAssertTrue(markdownMessage!.contains("SwiftLint found issues"))
+    }
+
+    func testQuotesPathArguments() {
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "Test Dir/SomeThirdFile.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+
+        XCTAssertTrue(swiftlintCommands.count > 0)
+
+        let spacedDirSwiftlintCommands = swiftlintCommands.filter { _, arguments in
+            arguments.contains("--path \"Test Dir/SomeThirdFile.swift\"")
+        }
+
+        XCTAssertEqual(spacedDirSwiftlintCommands.count, 1)
+    }
+
+    func mockViolationJSON() {
+        executor.output = """
+        [
+            {
+                "rule_id" : "opening_brace",
+                "reason" : "Opening braces should be preceded by a single space and on the same line as the declaration.",
+                "character" : 39,
+                "file" : "/Users/ash/bin/SomeFile.swift",
+                "severity" : "Warning",
+                "type" : "Opening Brace Spacing",
+                "line" : 8
+            }
+        ]
+        """
+    }
+
+    func writeMarkdown(_ m: String) {
+        markdownMessage = m
+    }
+
+    static var allTests = [
+        ("testExecutesTheShell", testExecutesTheShell),
+        ("testExecutesSwiftLintWithConfigWhenPassed", testExecutesSwiftLintWithConfigWhenPassed),
+        ("testExecutesSwiftLintWithDirectoryPassed", testExecutesSwiftLintWithDirectoryPassed),
+        ("testExecutesSwiftLintWhenLintingAllFiles", testExecutesSwiftLintWhenLintingAllFiles),
+        ("testExecutesSwiftLintWhenLintingAllFilesWithDirectoryPassed", testExecutesSwiftLintWhenLintingAllFilesWithDirectoryPassed),
+        ("testFiltersOnSwiftFiles", testFiltersOnSwiftFiles),
+        ("testPrintsNoMarkdownIfNoViolations", testPrintsNoMarkdownIfNoViolations),
+        ("testViolations", testViolations),
+        ("testMarkdownReporting", testMarkdownReporting),
+        ("testQuotesPathArguments", testQuotesPathArguments),
+    ]
+}

--- a/Tests/DangerTests/SwiftLint/FakeCurrentPathProvider.swift
+++ b/Tests/DangerTests/SwiftLint/FakeCurrentPathProvider.swift
@@ -1,0 +1,5 @@
+@testable import Danger
+
+final class FakeCurrentPathProvider: CurrentPathProvider {
+    var currentPath: String = ""
+}

--- a/Tests/DangerTests/SwiftLint/FakeShellExecutor.swift
+++ b/Tests/DangerTests/SwiftLint/FakeShellExecutor.swift
@@ -1,0 +1,13 @@
+@testable import Danger
+
+class FakeShellExecutor: ShellExecutor {
+    typealias Invocation = (command: String, arguments: [String])
+
+    var invocations = Array<Invocation>() /// All of the invocations received by this instance.
+    var output = "[]" /// This is returned by `execute` as the process' standard output. We default to an empty JSON array.
+
+    override func execute(_ command: String, arguments: String...) -> String {
+        invocations.append((command: command, arguments: arguments))
+        return output
+    }
+}

--- a/Tests/DangerTests/SwiftLint/URL+Utils.swift
+++ b/Tests/DangerTests/SwiftLint/URL+Utils.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension URL {
+    func deletingLastPathComponent(_ count: Int) -> URL {
+        guard count > 0 else { return self }
+
+        var newUrl = self
+        (0 ... count).forEach { _ in newUrl.deleteLastPathComponent() }
+
+        return newUrl
+    }
+}

--- a/Tests/DangerTests/SwiftLint/ViolationTests.swift
+++ b/Tests/DangerTests/SwiftLint/ViolationTests.swift
@@ -1,0 +1,30 @@
+@testable import Danger
+import XCTest
+
+class ViolnationTests: XCTestCase {
+    func testDecoding() {
+        let json = """
+        {
+            "rule_id" : "opening_brace",
+            "reason" : "Opening braces should be preceded by a single space and on the same line as the declaration.",
+            "character" : 39,
+            "file" : "/Users/ash/bin/Harvey/Sources/Harvey/Harvey.swift",
+            "severity" : "Warning",
+            "type" : "Opening Brace Spacing",
+            "line" : 8
+        }
+        """
+        let subject = try! JSONDecoder().decode(SwiftLintViolation.self, from: json.data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(subject.ruleID, "opening_brace")
+        XCTAssertEqual(subject.reason, "Opening braces should be preceded by a single space and on the same line as the declaration.")
+        XCTAssertEqual(subject.line, 8)
+        XCTAssertEqual(subject.character, 39)
+        XCTAssertEqual(subject.file, "/Users/ash/bin/Harvey/Sources/Harvey/Harvey.swift")
+        XCTAssertEqual(subject.severity, .warning)
+        XCTAssertEqual(subject.type, "Opening Brace Spacing")
+    }
+
+    static var allTests = [
+        ("testDecoding", testDecoding),
+    ]
+}

--- a/Tests/DangerTests/XCTestManifests.swift
+++ b/Tests/DangerTests/XCTestManifests.swift
@@ -20,6 +20,23 @@ extension DangerDSLTests {
     ]
 }
 
+extension DangerSwiftLintTests {
+    static let __allTests = [
+        ("testExecutesSwiftLintWhenLintingAllFiles", testExecutesSwiftLintWhenLintingAllFiles),
+        ("testExecutesSwiftLintWhenLintingAllFilesWithDirectoryPassed", testExecutesSwiftLintWhenLintingAllFilesWithDirectoryPassed),
+        ("testExecutesSwiftLintWithConfigWhenPassed", testExecutesSwiftLintWithConfigWhenPassed),
+        ("testExecutesSwiftLintWithDirectoryPassed", testExecutesSwiftLintWithDirectoryPassed),
+        ("testExecutesTheShell", testExecutesTheShell),
+        ("testExecutesTheShellWithCustomSwiftLintPath", testExecutesTheShellWithCustomSwiftLintPath),
+        ("testExecuteSwiftLintInInlineMode", testExecuteSwiftLintInInlineMode),
+        ("testFiltersOnSwiftFiles", testFiltersOnSwiftFiles),
+        ("testMarkdownReporting", testMarkdownReporting),
+        ("testPrintsNoMarkdownIfNoViolations", testPrintsNoMarkdownIfNoViolations),
+        ("testQuotesPathArguments", testQuotesPathArguments),
+        ("testViolations", testViolations),
+    ]
+}
+
 extension DateFormatterExtensionTests {
     static let __allTests = [
         ("test_DateFormatter_dateFromString", test_DateFormatter_dateFromString),
@@ -80,17 +97,25 @@ extension NSRegularExpressionExtensionsTests {
     ]
 }
 
+extension ViolnationTests {
+    static let __allTests = [
+        ("testDecoding", testDecoding),
+    ]
+}
+
 #if !os(macOS)
     public func __allTests() -> [XCTestCaseEntry] {
         return [
             testCase(BitBucketServerTests.__allTests),
             testCase(DangerDSLTests.__allTests),
+            testCase(DangerSwiftLintTests.__allTests),
             testCase(DateFormatterExtensionTests.__allTests),
             testCase(FileTests.__allTests),
             testCase(FileTypeTests.__allTests),
             testCase(GitHubTests.__allTests),
             testCase(GitTests.__allTests),
             testCase(NSRegularExpressionExtensionsTests.__allTests),
+            testCase(ViolnationTests.__allTests),
         ]
     }
 #endif


### PR DESCRIPTION
Closes https://github.com/ashfurrow/danger-swiftlint/issues/17 and merges SwiftLint into Danger. This will need another docs refresh, but then I think this'll get a big mention on the index for the website. 

I mainly brought it over wholesale, and then edited the tests to re-use some of the [new testing infra](https://github.com/danger/swift/blob/master/Documentation/usage/extending_danger_two.html.md) 

It'll need to support running via SwiftPM so we can use it on Danger Swift itself, but getting there.

This is a big enough move that I'd like to get sign off from both @ashfurrow @sunshinejr because moving this in re-assigns the copyright to the [Danger Swift license](https://github.com/danger/swift/blob/master/LICENSE) instead of the one from danger swiftlint.