### PR TITLE
Use a fake printer to avoid warnings to be printed on tests

### DIFF
--- a/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
+++ b/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
@@ -4,7 +4,7 @@ import Logger
 import XCTest
 
 final class DangerFileGeneratorTests: XCTestCase {
-    private let logger = Logger()
+    private let logger = Logger(isVerbose: false, isSilent: false, printer: SpyPrinter())
     private var createdFiles: [String] = []
     private var generator: DangerFileGenerator!
 

--- a/Tests/RunnerLibTests/HelpMessagePresenterTests.swift
+++ b/Tests/RunnerLibTests/HelpMessagePresenterTests.swift
@@ -11,7 +11,7 @@ final class HelpMessagePresenterTests: XCTestCase {
     }
 }
 
-private final class SpyPrinter: Printing {
+final class SpyPrinter: Printing {
     private(set) var printedMessages: [String] = []
 
     func print(_ message: String, terminator _: String) {


### PR DESCRIPTION
If you run the tests you will see 

```
WARNING: File not fount at GeneredTestFile3.swift
```

This is because we are using the real logger there