### PR TITLE
Fix danger report system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Fix danger report system by [@f-meloni][]
 - More docs by [@orta][]
 - Fixes for people installing via homebrew (thanks [@f-meloni][]) by [@orta][]
 

--- a/Sources/Danger/Report.swift
+++ b/Sources/Danger/Report.swift
@@ -13,13 +13,22 @@ private var testingResults = DangerResults()
 /// in the app all results are stored in a singleton,
 /// controlled by DangerRunner, but in tests they
 /// are accessible from the DangerResults object.
-var globalResults: DangerResults = {
-    if ProcessInfo.processInfo.processName.hasSuffix("xctest") {
-        return testingResults
-    } else {
-        return DangerRunner.shared.results
+var globalResults: DangerResults {
+    get {
+        if ProcessInfo.processInfo.processName.hasSuffix("xctest") {
+            return testingResults
+        } else {
+            return DangerRunner.shared.results
+        }
     }
-}()
+    set {
+        if ProcessInfo.processInfo.processName.hasSuffix("xctest") {
+            testingResults = newValue
+        } else {
+            DangerRunner.shared.results = newValue
+        }
+    }
+}
 
 /// Resets the results array, useful for having in
 /// setup functions for testing


### PR DESCRIPTION
`DangerResult` is a struct, on the old implementation it was copied, and the changes were not propagated to the original result object