### PR TITLE
Fail if danger-js version is below the minimum supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Fail if danger-js version is below the minimum supported version by [@f-meloni][]
 - Add method to get all the lines that contain a word on a file by [@f-meloni][]
 
 ## 0.8.1

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -4,6 +4,12 @@ import RunnerLib
 
 func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger) throws -> Int32 {
     let dangerJS = try getDangerCommandPath(logger: logger)
+    let dangerJSVersion = try DangerJSVersionFinder.findDangerJSVersion(dangerJSPath: dangerJS)
+
+    guard dangerJSVersion.compare(MinimumDangerJSVersion, options: .numeric) != .orderedAscending else {
+        logger.logError("The installed danger-js version is below the minimum supported version", "Current version = \(dangerJSVersion)", "Minimum supported version = \(MinimumDangerJSVersion)", separator: "\n")
+        exit(1)
+    }
 
     let proc = Process()
     proc.environment = ProcessInfo.processInfo.environment

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -4,6 +4,7 @@ import RunnerLib
 
 /// Version for showing in verbose mode
 let DangerVersion = "0.8.1"
+let MinimumDangerJSVersion = "6.1.6"
 
 private func runCommand(_ command: DangerCommand, logger: Logger) throws {
     switch command {

--- a/Sources/RunnerLib/DangerJSVersionFinder.swift
+++ b/Sources/RunnerLib/DangerJSVersionFinder.swift
@@ -1,0 +1,24 @@
+import Logger
+import ShellOut
+
+public final class DangerJSVersionFinder {
+    public static func findDangerJSVersion(dangerJSPath: String) throws -> String {
+        return try findDangerJSVersion(dangerJSPath: dangerJSPath, executor: ShellOutExecutor())
+    }
+
+    static func findDangerJSVersion(dangerJSPath: String, executor: ShellOutExecuting) throws -> String {
+        Logger().debug("Finding danger-js version")
+
+        return try executor.shellOut(command: dangerJSPath + " --version")
+    }
+}
+
+public protocol ShellOutExecuting {
+    func shellOut(command: String) throws -> String
+}
+
+public struct ShellOutExecutor: ShellOutExecuting {
+    public func shellOut(command: String) throws -> String {
+        return try ShellOut.shellOut(to: command)
+    }
+}

--- a/Tests/RunnerLibTests/DangerJSVersionFinderTests.swift
+++ b/Tests/RunnerLibTests/DangerJSVersionFinderTests.swift
@@ -1,0 +1,26 @@
+@testable import RunnerLib
+import XCTest
+
+final class DangerJSVersionFinderTests: XCTestCase {
+    func testItSendsTheCorrectCommandAndReturnsTheCorrectResult() throws {
+        let executor = MockedExecutor()
+        executor.result = "1.0.0"
+
+        let dangerJSPath = "/test/danger"
+
+        let version = try DangerJSVersionFinder.findDangerJSVersion(dangerJSPath: dangerJSPath, executor: executor)
+
+        XCTAssertEqual(executor.receivedCommand, dangerJSPath + " --version")
+        XCTAssertEqual(version, executor.result)
+    }
+}
+
+private final class MockedExecutor: ShellOutExecuting {
+    var receivedCommand: String!
+    var result = ""
+
+    func shellOut(command: String) throws -> String {
+        receivedCommand = command
+        return result
+    }
+}

--- a/Tests/RunnerLibTests/XCTestManifests.swift
+++ b/Tests/RunnerLibTests/XCTestManifests.swift
@@ -23,6 +23,12 @@ extension DangerFileGeneratorTests {
     ]
 }
 
+extension DangerJSVersionFinderTests {
+    static let __allTests = [
+        ("testItSendsTheCorrectCommandAndReturnsTheCorrectResult", testItSendsTheCorrectCommandAndReturnsTheCorrectResult),
+    ]
+}
+
 extension HelpMessagePresenterTests {
     static let __allTests = [
         ("testIsShowsTheCommandListWhenThereIsNoCommand", testIsShowsTheCommandListWhenThereIsNoCommand),
@@ -42,6 +48,7 @@ extension ImportsFinderTests {
             testCase(CliParserTests.__allTests),
             testCase(DangerCommandTests.__allTests),
             testCase(DangerFileGeneratorTests.__allTests),
+            testCase(DangerJSVersionFinderTests.__allTests),
             testCase(HelpMessagePresenterTests.__allTests),
             testCase(ImportsFinderTests.__allTests),
         ]


### PR DESCRIPTION
As discussed on https://github.com/danger/swift/issues/131 would be good if danger-swift would fail if the danger-js used version is not supported.
It would avoid problems like the one we had when we introduced `--passURLForDSL` argument, that was not supported before the 6.1.2