### PR TITLE
Improve invalid DSL error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Improve invalid DSL error message [@f-meloni][]
 - Fail if danger-js version is below the minimum supported version by [@f-meloni][]
 - Add method to get all the lines that contain a word on a file by [@f-meloni][]
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -28,7 +28,7 @@ func runDanger(logger: Logger) throws {
 
     // Pull our the JSON data so we can extract settings
     guard let dslJSONData = try? Data(contentsOf: URL(fileURLWithPath: dslJSONPath)) else {
-        logger.logError("Invalid DSL JSON data")
+        logger.logError("Invalid DSL JSON data", "if you are running danger-swift by using danger command --process danger-swift please run danger-swift command instead", separator: "\n")
         exit(1)
     }
 


### PR DESCRIPTION
Improves the Invalid DSL error message to include a message for people using `danger ci --process danger-swift` like on https://github.com/danger/swift/issues/133