### PR TITLE
Use SPM swiftlint if available

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,3 @@
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Dangerfile.swift
+  - Tests/*/XCTestManifests.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,0 @@
-excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Dangerfile.swift
-  - Tests/*/XCTestManifests.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,3 @@
+excluded:
+  - ".build"
+  - Tests/*/XCTestManifests.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,0 @@
-excluded:
-  - ".build"
-  - Tests/*/XCTestManifests.swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Run Swiftlint from SPM by default when available [@f-meloni][]
+
 ## 1.0.0
 
 It's time, Danger Swift now has enough to be useful to nearly everyone and is in use in production environments today.

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,6 +20,8 @@ if swiftFilesWithCopyright.count > 0 {
     warn("In Danger JS we don't include copyright headers, found them in: \(files)")
 }
 
+SwiftLint.lint()
+
 // Support running via `danger local`
 if danger.github != nil {
     // These checks only happen on a PR

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,7 +20,7 @@ if swiftFilesWithCopyright.count > 0 {
     warn("In Danger JS we don't include copyright headers, found them in: \(files)")
 }
 
-SwiftLint.lint()
+SwiftLint.lint(inline: true)
 
 // Support running via `danger local`
 if danger.github != nil {

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,7 +20,7 @@ if swiftFilesWithCopyright.count > 0 {
     warn("In Danger JS we don't include copyright headers, found them in: \(files)")
 }
 
-SwiftLint.lint(inline: true)
+SwiftLint.lint(inline: true, directory: "Sources")
 
 // Support running via `danger local`
 if danger.github != nil {

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -13,13 +13,19 @@ public struct SwiftLint {
     public static func lint(inline: Bool = false, directory: String? = nil,
                             configFile: String? = nil, lintAllFiles: Bool = false,
                             swiftlintPath: String? = nil) -> [SwiftLintViolation] {
-        return lint(danger: danger, shellExecutor: shellExecutor, swiftlintPath: swiftlintPath ?? SwiftLint.swiftlintDefaultPath(), inline: inline, directory: directory,
-                    configFile: configFile, lintAllFiles: lintAllFiles)
+        return lint(danger: danger,
+                    shellExecutor: shellExecutor,
+                    swiftlintPath: swiftlintPath ?? SwiftLint.swiftlintDefaultPath(),
+                    inline: inline,
+                    directory: directory,
+                    configFile: configFile,
+                    lintAllFiles: lintAllFiles)
     }
 }
 
 /// This extension is for internal workings of the plugin. It is marked as internal for unit testing.
 extension SwiftLint {
+    // swiftlint:disable:next function_body_length
     static func lint(
         danger: DangerDSL,
         shellExecutor: ShellExecutor,
@@ -47,7 +53,6 @@ extension SwiftLint {
             }
             let outputJSON = shellExecutor.execute(swiftlintPath, arguments: arguments)
             violations = makeViolations(from: outputJSON, failAction: failAction)
-
         } else {
             // Gathers modified+created files, invokes SwiftLint on each, and posts collected errors+warnings to Danger.
             var files = danger.git.createdFiles + danger.git.modifiedFiles
@@ -110,8 +115,9 @@ extension SwiftLint {
     }
 
     static func swiftlintDefaultPath(packagePath: String = "Package.swift") -> String {
+        let swiftPackageDepPattern = "\\.package\\(.*SwiftLint.*"
         if let packageContent = try? String(contentsOfFile: packagePath),
-            let regex = try? NSRegularExpression(pattern: "\\.package\\(.*SwiftLint.*", options: .allowCommentsAndWhitespace),
+            let regex = try? NSRegularExpression(pattern: swiftPackageDepPattern, options: .allowCommentsAndWhitespace),
             regex.firstMatchingString(in: packageContent) != nil {
             return "swift run swiftlint"
         } else {

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -13,7 +13,7 @@ public struct SwiftLint {
     public static func lint(inline: Bool = false, directory: String? = nil,
                             configFile: String? = nil, lintAllFiles: Bool = false,
                             swiftlintPath: String? = nil) -> [SwiftLintViolation] {
-        return lint(danger: danger, shellExecutor: shellExecutor, swiftlintPath: swiftlintPath ?? SwiftLint.swiftlintDefaultPath(packagePath: "Package.swift"), inline: inline, directory: directory,
+        return lint(danger: danger, shellExecutor: shellExecutor, swiftlintPath: swiftlintPath ?? SwiftLint.swiftlintDefaultPath(), inline: inline, directory: directory,
                     configFile: configFile, lintAllFiles: lintAllFiles)
     }
 }
@@ -109,7 +109,7 @@ extension SwiftLint {
         }
     }
 
-    static func swiftlintDefaultPath(packagePath: String) -> String {
+    static func swiftlintDefaultPath(packagePath: String = "Package.swift") -> String {
         if let packageContent = try? String(contentsOfFile: packagePath),
             let regex = try? NSRegularExpression(pattern: "\\.package\\(.*SwiftLint.*", options: .allowCommentsAndWhitespace),
             regex.firstMatchingString(in: packageContent) != nil {

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -7,7 +7,10 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
     let dangerJSVersion = try DangerJSVersionFinder.findDangerJSVersion(dangerJSPath: dangerJS)
 
     guard dangerJSVersion.compare(MinimumDangerJSVersion, options: .numeric) != .orderedAscending else {
-        logger.logError("The installed danger-js version is below the minimum supported version", "Current version = \(dangerJSVersion)", "Minimum supported version = \(MinimumDangerJSVersion)", separator: "\n")
+        logger.logError("The installed danger-js version is below the minimum supported version",
+                        "Current version = \(dangerJSVersion)",
+                        "Minimum supported version = \(MinimumDangerJSVersion)",
+                        separator: "\n")
         exit(1)
     }
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -28,7 +28,9 @@ func runDanger(logger: Logger) throws {
 
     // Pull our the JSON data so we can extract settings
     guard let dslJSONData = try? Data(contentsOf: URL(fileURLWithPath: dslJSONPath)) else {
-        logger.logError("Invalid DSL JSON data", "if you are running danger-swift by using danger command --process danger-swift please run danger-swift command instead", separator: "\n")
+        logger.logError("Invalid DSL JSON data",
+                        "If you are running danger-swift by using danger command --process danger-swift please run danger-swift command instead",
+                        separator: "\n")
         exit(1)
     }
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -5,6 +5,7 @@ import Logger
 import MarathonCore
 import RunnerLib
 
+// swiftlint:disable:next function_body_length
 func runDanger(logger: Logger) throws {
     // Pull in the JSON from Danger JS
 
@@ -29,7 +30,8 @@ func runDanger(logger: Logger) throws {
     // Pull our the JSON data so we can extract settings
     guard let dslJSONData = try? Data(contentsOf: URL(fileURLWithPath: dslJSONPath)) else {
         logger.logError("Invalid DSL JSON data",
-                        "If you are running danger-swift by using danger command --process danger-swift please run danger-swift command instead",
+                        "If you are running danger-swift by using danger command --process danger-swift" +
+                            "please run danger-swift command instead",
                         separator: "\n")
         exit(1)
     }
@@ -60,10 +62,12 @@ func runDanger(logger: Logger) throws {
 
     // Set up plugin infra
     let importsOnly = try File(path: dangerfilePath).readAsString()
-    let importExternalDeps = importsOnly.components(separatedBy: .newlines).filter { $0.hasPrefix("import") && $0.contains("package: ") }
+    let importExternalDeps = importsOnly.components(separatedBy: .newlines).filter { $0.hasPrefix("import") && $0.contains("package: ") } // swiftlint:disable:this line_length
 
     if importExternalDeps.count > 0 {
-        print("Cloning and building inline dependencies: \(importExternalDeps.joined(separator: ", ")), this might take some time.")
+        logger.logInfo("Cloning and building inline dependencies:",
+                       "\(importExternalDeps.joined(separator: ", ")),",
+                       "this might take some time.")
 
         try Folder(path: ".").createFileIfNeeded(withName: "_dangerfile_imports.swift")
         let tempDangerfile = try File(path: "_dangerfile_imports.swift")
@@ -91,17 +95,20 @@ func runDanger(logger: Logger) throws {
     let generator = DangerFileGenerator()
     try generator.generateDangerFile(fromContent: importsOnly, fileName: tempDangerfilePath, logger: logger)
 
+    // swiftlint:disable line_length
     // Example commands:
     //
     //
     // ## Run the full system:
-    // swift build; env DANGER_GITHUB_API_TOKEN='MY_TOKEN' DANGER_FAKE_CI="YEP" DANGER_TEST_REPO='artsy/eigen' DANGER_TEST_PR='2408' danger process .build/debug/danger-swift --verbose --text-only
+    // swift build;
+    // env DANGER_GITHUB_API_TOKEN='MY_TOKEN' DANGER_FAKE_CI="YEP" DANGER_TEST_REPO='artsy/eigen' DANGER_TEST_PR='2408' danger process .build/debug/danger-swift --verbose --text-only
     //
     // ## Run compilation and eval of the Dangerfile:
     // swiftc --driver-mode=swift -L .build/debug -I .build/debug -lDanger Dangerfile.swift Fixtures/eidolon_609.json Fixtures/response_data.json
     //
     // ## Run Danger Swift with a fixture'd JSON file
     // swift build; cat Fixtures/eidolon_609.json  | ./.build/debug/danger-swift
+    // swiftlint:enable line_length
 
     var args = [String]()
     args += ["--driver-mode=swift"] // Eval in swift mode, I think?

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -18,7 +18,7 @@ class DangerSwiftLintTests: XCTestCase {
     }
 
     func testExecutesTheShell() {
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider)
         XCTAssertNotEqual(executor.invocations.dropFirst().count, 0)
         XCTAssertEqual(executor.invocations.first?.command, "swiftlint")
     }
@@ -34,7 +34,7 @@ class DangerSwiftLintTests: XCTestCase {
         var warns = [(String, String, Int)]()
         let warnAction: (String, String, Int) -> Void = { warns.append(($0, $1, $2)) }
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, inline: true, currentPathProvider: fakePathProvider, warnInlineAction: warnAction)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", inline: true, currentPathProvider: fakePathProvider, warnInlineAction: warnAction)
 
         XCTAssertEqual(warns.first?.0, "Opening braces should be preceded by a single space and on the same line as the declaration.")
         XCTAssertEqual(warns.first?.1, "SomeFile.swift")
@@ -44,7 +44,7 @@ class DangerSwiftLintTests: XCTestCase {
     func testExecutesSwiftLintWithConfigWhenPassed() {
         let configFile = "/Path/to/config/.swiftlint.yml"
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, configFile: configFile, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", configFile: configFile, currentPathProvider: fakePathProvider)
 
         let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
         XCTAssertTrue(swiftlintCommands.count > 0)
@@ -63,7 +63,7 @@ class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, directory: directory, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", directory: directory, currentPathProvider: fakePathProvider)
 
         let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
         XCTAssertEqual(swiftlintCommands.count, 1)
@@ -79,7 +79,7 @@ class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, lintAllFiles: true, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", lintAllFiles: true, currentPathProvider: fakePathProvider)
 
         let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
         XCTAssertEqual(swiftlintCommands.count, 1)
@@ -96,7 +96,7 @@ class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, directory: directory, lintAllFiles: true, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", directory: directory, lintAllFiles: true, currentPathProvider: fakePathProvider)
 
         let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
         XCTAssertEqual(swiftlintCommands.count, 1)
@@ -105,7 +105,7 @@ class DangerSwiftLintTests: XCTestCase {
     }
 
     func testFiltersOnSwiftFiles() {
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider)
 
         let quoteCharacterSet = CharacterSet(charactersIn: "\"")
         let filesExtensions = Set(executor.invocations.dropFirst().compactMap { $0.arguments[2].split(separator: ".").last?.trimmingCharacters(in: quoteCharacterSet) })
@@ -113,7 +113,7 @@ class DangerSwiftLintTests: XCTestCase {
     }
 
     func testPrintsNoMarkdownIfNoViolations() {
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider)
         XCTAssertNil(markdownMessage)
     }
 
@@ -126,13 +126,13 @@ class DangerSwiftLintTests: XCTestCase {
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
         mockViolationJSON()
 
-        let violations = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
+        let violations = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
         XCTAssertEqual(violations.count, 2) // Two files, one (identical oops) violation returned for each.
     }
 
     func testMarkdownReporting() {
         mockViolationJSON()
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
         XCTAssertNotNil(markdownMessage)
         XCTAssertTrue(markdownMessage!.contains("SwiftLint found issues"))
     }
@@ -146,7 +146,7 @@ class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider)
 
         let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
 

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -175,8 +175,8 @@ class DangerSwiftLintTests: XCTestCase {
         """
     }
 
-    func writeMarkdown(_ m: String) {
-        markdownMessage = m
+    func writeMarkdown(_ message: String) {
+        markdownMessage = message
     }
 
     static var allTests = [

--- a/Tests/DangerTests/SwiftLint/SwiftlintDefaultPathTests.swift
+++ b/Tests/DangerTests/SwiftLint/SwiftlintDefaultPathTests.swift
@@ -1,0 +1,62 @@
+@testable import Danger
+import XCTest
+
+final class SwiftlintDefaultPathTests: XCTestCase {
+    let package = "testPackage.swift"
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: package)
+        super.tearDown()
+    }
+
+    func testItReturnsTheSPMCommandIfThePackageContainsTheSwiftlintDependency() {
+        givenAFakePackage(hasSwiftlintDep: true)
+
+        XCTAssertEqual(SwiftLint.swiftlintDefaultPath(packagePath: package), "swift run swiftlint")
+    }
+
+    func testItReturnsTheSwiftlintCLICommandIfThePackageContainsTheSwiftlintDependency() {
+        givenAFakePackage(hasSwiftlintDep: false)
+
+        XCTAssertEqual(SwiftLint.swiftlintDefaultPath(packagePath: package), "swiftlint")
+    }
+
+    private func givenAFakePackage(hasSwiftlintDep: Bool) {
+        try? """
+        // swift-tools-version:4.2
+
+        import PackageDescription
+
+        // Version number can be found in Source/Danger/Danger.swift
+
+        let package = Package(
+        name: "danger-swift",
+        products: [
+            .library(name: "Danger", type: .dynamic, targets: ["Danger"]),
+            .library(name: "DangerFixtures", type: .dynamic, targets: ["DangerFixtures"]),
+            .executable(name: "danger-swift", targets: ["Runner"]),
+        ],
+        dependencies: [
+            .package(url: "https://github.com/f-meloni/Logger", from: "0.1.0"),
+            .package(url: "https://github.com/JohnSundell/Marathon", from: "3.1.0"),
+            .package(url: "https://github.com/JohnSundell/ShellOut", from: "2.1.0"),
+            .package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.9.0"),
+            // Danger Plugins
+            // Dev dependencies
+            .package(url: "https://github.com/eneko/SourceDocs", from: "0.5.1"), // dev
+            .package(url: "https://github.com/orta/Komondor", from: "1.0.0"), // dev
+            .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.35.8"), // dev
+            \(hasSwiftlintDep ? ".package(url: \"https://github.com/Realm/SwiftLint\", from: \"0.28.1\")" : "")
+            .package(url: "https://github.com/f-meloni/Rocket", from: "0.4.0"), // dev
+        ],
+        targets: [
+            .target(name: "Danger", dependencies: ["ShellOut", "OctoKit", "Logger"]),
+            .target(name: "RunnerLib", dependencies: ["Logger", "ShellOut"]),
+            .target(name: "Runner", dependencies: ["RunnerLib", "MarathonCore", "Logger"]),
+            .target(name: "DangerFixtures", dependencies: ["Danger"]),
+            .testTarget(name: "DangerTests", dependencies: ["Danger", "DangerFixtures"]),
+            .testTarget(name: "RunnerLibTests", dependencies: ["RunnerLib"]),
+        ])
+        """.write(toFile: package, atomically: false, encoding: .utf8)
+    }
+}

--- a/Tests/DangerTests/XCTestManifests.swift
+++ b/Tests/DangerTests/XCTestManifests.swift
@@ -104,6 +104,13 @@ extension NSRegularExpressionExtensionsTests {
     ]
 }
 
+extension SwiftlintDefaultPathTests {
+    static let __allTests = [
+        ("testItReturnsTheSPMCommandIfThePackageContainsTheSwiftlintDependency", testItReturnsTheSPMCommandIfThePackageContainsTheSwiftlintDependency),
+        ("testItReturnsTheSwiftlintCLICommandIfThePackageContainsTheSwiftlintDependency", testItReturnsTheSwiftlintCLICommandIfThePackageContainsTheSwiftlintDependency),
+    ]
+}
+
 extension ViolnationTests {
     static let __allTests = [
         ("testDecoding", testDecoding),
@@ -123,6 +130,7 @@ extension ViolnationTests {
             testCase(GitHubTests.__allTests),
             testCase(GitTests.__allTests),
             testCase(NSRegularExpressionExtensionsTests.__allTests),
+            testCase(SwiftlintDefaultPathTests.__allTests),
             testCase(ViolnationTests.__allTests),
         ]
     }


### PR DESCRIPTION
Given we have SPM as suggested install method for danger i thought would be cool using SPM for swiftlint as well.
Then `swift run swiftlint` is called by default if you call `Swiftlint.lint()` and you have `SwiftLint` dep on your `Pacakge.swift`