### PR TITLE
Append rule id to the Swiftlint message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Append Swiftlint rule id to the Swiftlint danger messages [@f-meloni][]
 - Run Swiftlint from SPM by default when available [@f-meloni][]
 
 ## 1.0.0

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -83,9 +83,9 @@ extension SwiftLint {
                 violations.forEach { violation in
                     switch violation.severity {
                     case .error:
-                        failInlineAction(violation.reason, violation.file, violation.line)
+                        failInlineAction(violation.messageText, violation.file, violation.line)
                     case .warning:
-                        warnInlineAction(violation.reason, violation.file, violation.line)
+                        warnInlineAction(violation.messageText, violation.file, violation.line)
                     }
                 }
             } else {

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
@@ -11,6 +11,10 @@ public struct SwiftLintViolation: Codable {
     let severity: Severity
     let type: String
 
+    var messageText: String {
+        return reason + " (\(ruleID))"
+    }
+
     private(set) var file: String
 
     enum CodingKeys: String, CodingKey {
@@ -31,7 +35,7 @@ public struct SwiftLintViolation: Codable {
 
     public func toMarkdown() -> String {
         let formattedFile = file.split(separator: "/").last! + ":\(line)"
-        return "\(severity.rawValue) | \(formattedFile) | \(reason) |"
+        return "\(severity.rawValue) | \(formattedFile) | \(messageText) |"
     }
 
     mutating func update(file: String) {

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -33,12 +33,18 @@ class DangerSwiftLintTests: XCTestCase {
         mockViolationJSON()
         var warns = [(String, String, Int)]()
         let warnAction: (String, String, Int) -> Void = { warns.append(($0, $1, $2)) }
+        var fails = [(String, String, Int)]()
+        let failAction: (String, String, Int) -> Void = { fails.append(($0, $1, $2)) }
 
-        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", inline: true, currentPathProvider: fakePathProvider, warnInlineAction: warnAction)
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", inline: true, currentPathProvider: fakePathProvider, failInlineAction: failAction, warnInlineAction: warnAction)
 
-        XCTAssertEqual(warns.first?.0, "Opening braces should be preceded by a single space and on the same line as the declaration.")
+        XCTAssertEqual(warns.first?.0, "Opening braces should be preceded by a single space and on the same line as the declaration. (opening_brace)")
         XCTAssertEqual(warns.first?.1, "SomeFile.swift")
         XCTAssertEqual(warns.first?.2, 8)
+
+        XCTAssertEqual(fails.first?.0, "Line should be 120 characters or less: currently 211 characters (line_length)")
+        XCTAssertEqual(fails.first?.1, "AnotherFile.swift")
+        XCTAssertEqual(fails.first?.2, 10)
     }
 
     func testExecutesSwiftLintWithConfigWhenPassed() {
@@ -127,7 +133,7 @@ class DangerSwiftLintTests: XCTestCase {
         mockViolationJSON()
 
         let violations = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
-        XCTAssertEqual(violations.count, 2) // Two files, one (identical oops) violation returned for each.
+        XCTAssertEqual(violations.count, 4) // Two files, one (identical oops) violation returned for each.
     }
 
     func testMarkdownReporting() {
@@ -135,6 +141,7 @@ class DangerSwiftLintTests: XCTestCase {
         _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "swiftlint", currentPathProvider: fakePathProvider, markdownAction: writeMarkdown)
         XCTAssertNotNil(markdownMessage)
         XCTAssertTrue(markdownMessage!.contains("SwiftLint found issues"))
+        XCTAssertTrue(markdownMessage!.contains("Opening braces should be preceded by a single space and on the same line as the declaration. (opening_brace)")) // swiftlint:disable:this line_length
     }
 
     func testQuotesPathArguments() {
@@ -170,6 +177,15 @@ class DangerSwiftLintTests: XCTestCase {
                 "severity" : "Warning",
                 "type" : "Opening Brace Spacing",
                 "line" : 8
+            },
+            {
+                "rule_id" : "line_length",
+                "reason" : "Line should be 120 characters or less: currently 211 characters",
+                "character" : null,
+                "file" : "/Users/ash/bin/AnotherFile.swift",
+                "severity" : "Error",
+                "type" : "Line Length",
+                "line" : 10
             }
         ]
         """


### PR DESCRIPTION
This is really useful if you want to disable the rule.
Emulates the default that swiftlint text on xcode.
![swiftlint](https://user-images.githubusercontent.com/17830956/50609479-a457a980-0ec7-11e9-9fd0-5cb71774d4e6.png)