### PR TITLE
Add comment to explain what is swiftlintPath default value #trivial

### DIFF
--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -8,6 +8,10 @@ public struct SwiftLint {
     internal static let shellExecutor = ShellExecutor()
 
     /// This is the main entry point for linting Swift in PRs.
+    ///
+    /// When the swiftlintPath is not specified,
+    /// it uses by default swift run swiftlint if the Package.swift contains swiftlint as dependency,
+    /// otherwise calls directly the swiftlint command
 
     @discardableResult
     public static func lint(inline: Bool = false, directory: String? = nil,


### PR DESCRIPTION
I wanted to explain to people what is going to be used if they don't specify the `swiftlintPath` on the swiftlint call.
This in my opinion is also a way to make people evaluate SPM as tool to import `Swiftlint` in the project if they were not thinking about it.