### PR TITLE
Updated Logger and Rocket

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/f-meloni/Logger",
         "state": {
           "branch": null,
-          "revision": "ca5703dd05cabad21ee6cd77023a7bb7d5c9eeba",
-          "version": "0.2.1"
+          "revision": "c1cb5a142b99687ecc55d8de101bf082889f5fd1",
+          "version": "0.2.2"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/f-meloni/Rocket",
         "state": {
           "branch": null,
-          "revision": "dee2900896fc9831f6169752784f82b707a150bf",
-          "version": "0.4.0"
+          "revision": "1a9686ff181740274b7421894d161bdd97b0af6b",
+          "version": "0.4.1"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/JohnSundell/ShellOut",
         "state": {
           "branch": null,
-          "revision": "f1c253a34a40df4bfd268b09fdb101b059f6d52d",
-          "version": "2.1.0"
+          "revision": "d3d54ce662dfee7fef619330b71d251b8d4869f9",
+          "version": "2.2.0"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "67219a30460f0459bfbe4b21e8bb55cc70bcbf50",
-          "version": "0.37.1"
+          "revision": "aaed92d1b05a65f6ad385f79ca49e8f1747226ac",
+          "version": "0.37.2"
         }
       },
       {
@@ -215,15 +215,6 @@
           "branch": null,
           "revision": "9ba116841126f6c63435beef21a4cd247c32d2e7",
           "version": "4.7.6"
-        }
-      },
-      {
-        "package": "TestSpy",
-        "repositoryURL": "https://github.com/f-meloni/TestSpy",
-        "state": {
-          "branch": null,
-          "revision": "e0f1e9d4d10080762bb3b5256a94f347e74416f0",
-          "version": "0.3.1"
         }
       },
       {


### PR DESCRIPTION
I've added the test target to the "dev dependencies" (https://github.com/f-meloni/Logger/pull/4/files), then i could remove TestSpy from the dependencies, and it should remove Nimble too when is released.
This means faster install time and faster marathon time if you have a plugin 🎉 