### PR TITLE
Fix failing Swiftlint path trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Replace codable where was not needed by [@f-meloni][] - [#177](https://github.com/danger/swift/pull/177)
+- Fix malformed Swiftlint inline paths by [@absolute-heike][] - [#176](https://github.com/danger/swift/pull/176)
 
 ## 1.1.0
 

--- a/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
+++ b/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
@@ -6,6 +6,6 @@ internal protocol CurrentPathProvider {
 
 internal final class DefaultCurrentPathProvider: CurrentPathProvider {
     var currentPath: String {
-        return ShellExecutor().execute("pwd")
+        return ShellExecutor().execute("pwd").trimmingCharacters(in: .newlines)
     }
 }

--- a/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
+++ b/Sources/Danger/Plugins/SwiftLint/CurrentPathProvider.swift
@@ -6,6 +6,6 @@ internal protocol CurrentPathProvider {
 
 internal final class DefaultCurrentPathProvider: CurrentPathProvider {
     var currentPath: String {
-        return ShellExecutor().execute("pwd").trimmingCharacters(in: .newlines)
+        return FileManager.default.currentDirectoryPath
     }
 }


### PR DESCRIPTION
https://github.com/danger/swift/blob/master/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift#L79

```swift
let currentPath = currentPathProvider.currentPath
violations = violations.map { violation in
    let updatedPath = violation.file.deletingPrefix(currentPath).deletingPrefix("/")
    var violation = violation
    violation.update(file: updatedPath)
    return violation
}
```

Deleting the current path would fail, because the current path would include a newline at the end of the path.

See issue: https://github.com/danger/swift/issues/176