### PR TITLE
Set Danger package version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN git clone https://github.com/danger/danger-swift.git _danger-swift
 RUN cd _danger-swift && make install
 
 # Run Danger Swift via Danger JS, allowing for custom args
-ENTRYPOINT ["npx", "--package", "danger@beta", "danger-swift", "ci"]
+ENTRYPOINT ["npx", "--package", "danger", "danger-swift", "ci"]


### PR DESCRIPTION
At the moment beta points to version 5.0.0-beta-24 which is less than required in `main.swift` by `MinimumDangerJSVersion = “6.1.6”`.