### PR TITLE
Leave SPM decide if build again or not the DangerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Leave SPM decide if rebuild or not the dependencies library [@f-meloni][]  - [#183](https://github.com/danger/swift/pull/183)
 - Fix excluded Swiftlint paths [@absolute-heike][] - [#180](https://github.com/danger/swift/pull/180)
 
 ## 1.2.1

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -24,7 +24,7 @@ func editDanger(logger: Logger) throws {
     let libName: String
 
     if let spmDanger = SPMDanger() {
-        spmDanger.buildDepsIfNeeded()
+        spmDanger.buildDependencies()
         absoluteLibPath = FileManager.default.currentDirectoryPath + "/" + SPMDanger.buildFolder
         libName = spmDanger.depsLibName
     } else {

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -54,7 +54,7 @@ func runDanger(logger: Logger) throws {
     let importsOnly = try File(path: dangerfilePath).readAsString()
 
     if let spmDanger = SPMDanger() {
-        spmDanger.buildDepsIfNeeded()
+        spmDanger.buildDependencies()
         libArgs += ["-L", SPMDanger.buildFolder]
         libArgs += ["-I", SPMDanger.buildFolder]
         libArgs += [spmDanger.libImport]

--- a/Sources/RunnerLib/SPMDanger.swift
+++ b/Sources/RunnerLib/SPMDanger.swift
@@ -22,12 +22,9 @@ public struct SPMDanger {
         }
     }
 
-    public func buildDepsIfNeeded(executor: ShellOutExecuting = ShellOutExecutor(),
-                                  fileManager: FileManager = .default) {
-        if !fileManager.fileExists(atPath: "\(SPMDanger.buildFolder)/lib\(depsLibName).dylib"), // OSX
-            !fileManager.fileExists(atPath: "\(SPMDanger.buildFolder)/lib\(depsLibName).so") { // Linux
-            _ = try? executor.shellOut(command: "swift build --product \(depsLibName)")
-        }
+    public func buildDependencies(executor: ShellOutExecuting = ShellOutExecutor(),
+                                  fileManager _: FileManager = .default) {
+        _ = try? executor.shellOut(command: "swift build --product \(depsLibName)")
     }
 
     public var libImport: String {

--- a/Sources/RunnerLib/SPMDanger.swift
+++ b/Sources/RunnerLib/SPMDanger.swift
@@ -8,7 +8,8 @@ public struct SPMDanger {
     public init?(packagePath: String = "Package.swift") {
         let packageContent = (try? String(contentsOfFile: packagePath)) ?? ""
 
-        let regex = try? NSRegularExpression(pattern: "\\.library\\(name:[\\ ]?\"(\(SPMDanger.dangerDepsPrefix)[A-Za-z]*)",
+        let regexPattern = "\\.library\\(name:[\\ ]?\"(\(SPMDanger.dangerDepsPrefix)[A-Za-z]*)"
+        let regex = try? NSRegularExpression(pattern: regexPattern,
                                              options: .allowCommentsAndWhitespace)
         let firstMatch = regex?.firstMatch(in: packageContent,
                                            options: .withTransparentBounds,

--- a/Tests/RunnerLibTests/SPMDangerTests.swift
+++ b/Tests/RunnerLibTests/SPMDangerTests.swift
@@ -33,25 +33,15 @@ final class SPMDangerTests: XCTestCase {
         XCTAssertNil(SPMDanger(packagePath: testPackage))
     }
 
-    func testItBuildsTheDependenciesIfTheDepsLibIsNotPresent() {
+    func testItBuildsTheDependencies() {
         let executor = MockedExecutor()
         let fileManager = StubbedFileManager()
         fileManager.stubbedFileExists = false
 
         try! ".library(name: \"DangerDeps\"".write(toFile: testPackage, atomically: false, encoding: .utf8)
-        SPMDanger(packagePath: testPackage)?.buildDepsIfNeeded(executor: executor, fileManager: fileManager)
+        SPMDanger(packagePath: testPackage)?.buildDependencies(executor: executor, fileManager: fileManager)
 
         XCTAssertTrue(executor.receivedCommand == "swift build --product DangerDeps")
-    }
-
-    func testItDoesntBuildTheDependenciesIfTheDepsLibIsPresent() {
-        let executor = MockedExecutor()
-        let fileManager = StubbedFileManager()
-        fileManager.stubbedFileExists = true
-
-        SPMDanger(packagePath: testPackage)?.buildDepsIfNeeded(executor: executor, fileManager: fileManager)
-
-        XCTAssertTrue(executor.receivedCommand == nil)
     }
 
     func testItReturnsTheCorrectDepsImport() {

--- a/Tests/RunnerLibTests/XCTestManifests.swift
+++ b/Tests/RunnerLibTests/XCTestManifests.swift
@@ -45,8 +45,7 @@ extension ImportsFinderTests {
 extension SPMDangerTests {
     static let __allTests = [
         ("testItAcceptsAnythingStartsWithDangerDeps", testItAcceptsAnythingStartsWithDangerDeps),
-        ("testItBuildsTheDependenciesIfTheDepsLibIsNotPresent", testItBuildsTheDependenciesIfTheDepsLibIsNotPresent),
-        ("testItDoesntBuildTheDependenciesIfTheDepsLibIsPresent", testItDoesntBuildTheDependenciesIfTheDepsLibIsPresent),
+        ("testItBuildsTheDependencies", testItBuildsTheDependencies),
         ("testItReturnsFalseWhenThePackageHasNotTheDangerLib", testItReturnsFalseWhenThePackageHasNotTheDangerLib),
         ("testItReturnsFalseWhenThereIsNoPackage", testItReturnsFalseWhenThereIsNoPackage),
         ("testItReturnsTheCorrectDepsImport", testItReturnsTheCorrectDepsImport),


### PR DESCRIPTION
When I wrote this code I added a check to avoid to re build the library if was already on `.build`
With that you can end up in some corner cases if you change something (you add a dependency for example), and you have the .build cached, because the library is already builded and it won't be builded again.
SPM should anyway avoid to rebuild it if is already correctly builded, then i will leave the SPM algorithm decide