### PR TITLE
Add SwiftLint to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,15 @@ LABEL "com.github.actions.description"="Runs Swift Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
+ARG SWIFT_LINT_VER=0.30.1
+
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
 RUN apt-get install -y nodejs
+
+# install SwiftLint
+RUN git clone -b $SWIFT_LINT_VER --single-branch --depth 1 https://github.com/realm/SwiftLint.git _SwiftLint
+RUN cd _SwiftLint && git submodule update --init --recursive; make install
 
 # Install danger-swift globally
 RUN git clone https://github.com/danger/danger-swift.git _danger-swift


### PR DESCRIPTION
At the moment SwiftLint plugin assumes that swiftlint binary is already available through shell or it can be installed using SPM. But `danger/swift` releases don't include SwiftLint (it and other "dev" packages are commented out).