### PR TITLE
Set github as var to make danger compile with swift 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Set github as var to make danger compile with swift 5 [@f-meloni][]  - [#191](https://github.com/danger/swift/pull/191)
+
 ## 1.3.0
 
 - Accept dangerfile parameter on edit command  [@f-meloni][]  - [#189](https://github.com/danger/swift/pull/189)

--- a/Sources/Danger/DangerDSL.swift
+++ b/Sources/Danger/DangerDSL.swift
@@ -13,7 +13,7 @@ public struct DSL: Decodable {
 public struct DangerDSL: Decodable {
     public let git: Git
 
-    public let github: GitHub!
+    private(set) public var github: GitHub!
 
     public let bitbucketServer: BitBucketServer!
 


### PR DESCRIPTION
Given we set `github.api` here https://github.com/danger/swift/blob/master/Sources/Danger/DangerDSL.swift#L61 on Swift 5 is required for github to be a `var`