### PR TITLE
Support custom danger-js path

### DIFF
--- a/Sources/RunnerLib/GetDangerJSPath.swift
+++ b/Sources/RunnerLib/GetDangerJSPath.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Logger
+import ShellOut
+
+public func getDangerCommandPath(logger: Logger, args: [String] = CommandLine.arguments, shellOutExecutor: ShellOutExecuting = ShellOutExecutor()) throws -> String {
+    if let dangerJSPathOptionIndex = args.firstIndex(of: "--danger-js-path"),
+        dangerJSPathOptionIndex + 1 < args.count {
+        return args[dangerJSPathOptionIndex + 1]
+    } else {
+        logger.debug("Finding out where the danger executable is")
+        return try shellOutExecutor.shellOut(command: "which danger").trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Sources/RunnerLib/getDangerJSPath.swift
+++ b/Sources/RunnerLib/getDangerJSPath.swift
@@ -1,8 +1,0 @@
-import Foundation
-import Logger
-import ShellOut
-
-public func getDangerCommandPath(logger: Logger) throws -> String {
-    logger.debug("Finding out where the danger executable is")
-    return try shellOut(to: "which danger").trimmingCharacters(in: .whitespaces)
-}

--- a/Tests/RunnerLibTests/GetDangerJSPathTests.swift
+++ b/Tests/RunnerLibTests/GetDangerJSPathTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import Logger
+@testable import RunnerLib
+
+final class GetDangerJSPathTests: XCTestCase {
+    private let logger = Logger(isVerbose: false, isSilent: false, printer: SpyPrinter())
+    
+    func testItUsesTheDangerJSPathOptionIfPresent() throws {
+        let expectedResult = "/franco/test/danger-js"
+        let path = try getDangerCommandPath(logger: logger, args: ["test", "--danger-js-path", expectedResult])
+        XCTAssertEqual(path, expectedResult)
+    }
+    
+    func testItSearchesForDangerJSIfTheDangerJSPathOptionIsNotPresent() throws {
+        let executor = MockedExecutor()
+        let expectedResult = "/usr/test/danger-js"
+        executor.result = expectedResult
+        
+        let path = try getDangerCommandPath(logger: logger, args: [], shellOutExecutor: executor)
+        XCTAssertEqual(executor.receivedCommand, "which danger")
+        XCTAssertEqual(path, expectedResult)
+    }
+}


### PR DESCRIPTION
It would be cool to allow people to embed a compiled `danger-js` in their repo if they want