### PR TITLE
Prevent homebrew tap creation for forks

### DIFF
--- a/Scripts/create_homebrew_tap.sh
+++ b/Scripts/create_homebrew_tap.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Clone tap repo
 
+GIT_ORIGIN_NAME=`git remote get-url origin`
+if [[ $GIT_ORIGIN_NAME != *"danger/"* ]]; then
+  echo "Not creating homebrew tap because the git remote 'origin' is not in the danger organisation"
+  exit
+fi
+
 TOOL_NAME=danger-swift
 
 HOMEBREW_TAP_TMPDIR=$(mktemp -d)


### PR DESCRIPTION
I was creating a new release in my fork and it pushed an update to https://github.com/danger/homebrew-tap (I have reverted this change)

It feels like this should only happen when releasing to this repo, so I updated the deployment script