### PR TITLE
Fix danger-swift parameters filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix danger-swift parameters filter [@f-meloni][] - [#216](https://github.com/danger/swift/pull/216)
+
 ## 1.5.1
 
 - Support danger swift options and don't pass them to danger ci [@f-meloni][] - [#215](https://github.com/danger/swift/pull/215)

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -18,11 +18,17 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
     proc.environment = ProcessInfo.processInfo.environment
     proc.launchPath = dangerJS
 
-    let dangerOptionsIndexes = DangerSwiftOptions.allCases
-        .compactMap { ($0, CommandLine.arguments.firstIndex(of: $0.rawValue)) }
+    let dangerOptionsIndexes = DangerSwiftOption.allCases
+        .compactMap { option -> (DangerSwiftOption, Int)? in
+            if let index = CommandLine.arguments.firstIndex(of: option.rawValue) {
+                return (option, index)
+            } else {
+                return nil
+            }
+        }
 
     let unusedArgs = CommandLine.arguments.enumerated().compactMap { index, arg -> String? in
-        if dangerOptionsIndexes.contains(where: { index == $0.1 || ($0.0.hasParameter && index + 1 == $0.1) }) {
+        if dangerOptionsIndexes.contains(where: { index == $0.1 || ($0.0.hasParameter && index == $0.1 + 1) }) {
             return nil
         }
 

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -32,7 +32,7 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
             return nil
         }
 
-        if arg.contains("danger-swift"), arg == command.rawValue {
+        if arg.contains("danger-swift") || arg == command.rawValue {
             return nil
         }
 

--- a/Sources/RunnerLib/DangerSwiftOption.swift
+++ b/Sources/RunnerLib/DangerSwiftOption.swift
@@ -1,6 +1,6 @@
 // Options handled directly by Danger swift and not sent back to Danger JS
 
-public enum DangerSwiftOptions: String, CaseIterable {
+public enum DangerSwiftOption: String, CaseIterable {
     case dangerJSPath = "--danger-js-path"
 
     public var hasParameter: Bool {

--- a/Sources/RunnerLib/GetDangerJSPath.swift
+++ b/Sources/RunnerLib/GetDangerJSPath.swift
@@ -3,7 +3,7 @@ import Logger
 import ShellOut
 
 public func getDangerCommandPath(logger: Logger, args: [String] = CommandLine.arguments, shellOutExecutor: ShellOutExecuting = ShellOutExecutor()) throws -> String {
-    if let dangerJSPathOptionIndex = args.firstIndex(of: DangerSwiftOptions.dangerJSPath.rawValue),
+    if let dangerJSPathOptionIndex = args.firstIndex(of: DangerSwiftOption.dangerJSPath.rawValue),
         dangerJSPathOptionIndex + 1 < args.count {
         return args[dangerJSPathOptionIndex + 1]
     } else {


### PR DESCRIPTION
The filter was removing the parameter before the option instead of the one after