### PR TITLE
Remove swift 4.0 CaseIterable implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Remove swift 4.0 CaseIterable implementation [@f-meloni][] - [#235](https://github.com/danger/swift/pull/238)
 - Use enumerated to improve lines(for:, inFile:) function [@f-meloni][] - [#235](https://github.com/danger/swift/pull/235)
 - Remove not needed force unwrap [@f-meloni][] - [#234](https://github.com/danger/swift/pull/234)
 - Remove not needed coding keys [@f-meloni][] - [#233](https://github.com/danger/swift/pull/233)

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -17,20 +17,10 @@ extension File {
 
 // MARK: - FileType
 
-public enum FileType: String, Equatable {
+public enum FileType: String, Equatable, CaseIterable {
     // swiftlint:disable:next identifier_name
     case h, json, m, markdown = "md", mm, pbxproj, plist, storyboard, swift, xcscheme, yaml, yml
 }
-
-#if swift(>=4.2) // Use compiler-generated allCases when available
-    extension FileType: CaseIterable {}
-#else
-    extension FileType {
-        static var allCases: [FileType] {
-            return [.h, .json, .m, .markdown, .mm, .pbxproj, .plist, .storyboard, .swift, .xcscheme, .yaml, .yml]
-        }
-    }
-#endif
 
 // MARK: - FileType extensions
 


### PR DESCRIPTION
Since we support only from swift `4.2`, the ifdef was not needed anymore