### PR TITLE
Update Architecture documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Update Architecture documentation [@mollyIV][] - [#250](https://github.com/danger/swift/pull/250)
+
 ## 1.6.1
 
 - Make GitLab pipeline optional [@f-meloni][] - [#248](https://github.com/danger/swift/pull/248)
@@ -304,3 +306,4 @@ This release also includes:
 [@davdroman]: https://github.com/davdroman
 [139]: https://github.com/danger/swift/issues/139
 [99]: https://github.com/danger/swift/issues/99
+[@mollyIV]: https://github.com/mollyIV

--- a/Documentation/tutorials/architecture.html.md
+++ b/Documentation/tutorials/architecture.html.md
@@ -35,8 +35,7 @@ your Swift rules back to Danger JS.
 `source/ci_source/providers`][provs]. These use ENV VARs to figure out which CI `danger ci` is running on and validate
 whether it is a pull request.
 
-**Step 2: Platform**. Next, Danger JS needs to know which platform the code review is happening in. Today it's just
-GitHub and BitBucket Server, but maybe GitLab is around the corner.
+**Step 2: Platform**. Next, Danger JS needs to know which platform the code review is happening in. Today it's GitHub, BitBucket Server and GitLab.
 
 **Step 3: JSON DSL**. All the metadata from the above two steps are transformed into a JSON file, which is passed into
 Danger Swift.


### PR DESCRIPTION
Recently [GitLab support PR](https://github.com/danger/swift/pull/246) has been merged. Due to that, a [documentation](https://danger.systems/swift/tutorials/architecture.html) should be updated.

closes https://github.com/danger/swift/issues/249