### PR TITLE
Danger.xcodeproj is renamed to danger-swift.xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cd danger-swift
 swift build
 swift run komondor install
 swift package generate-xcodeproj
-open Danger.xcodeproj
+open danger-swift.xcodeproj
 ```
 
 Then I tend to run `danger-swift` using `swift run`:


### PR DESCRIPTION
For the sake of the development code setup, I needed to fix **Danger**.xcodeproj to **danger-swift**.xcodeproj