### PR TITLE
Fix not to log in to shell twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+## 2.0.2
+
+- Fix not to log in to shell twice [@manicmaniac][] - [#264](https://github.com/danger/swift/pull/264)
+
 ## 2.0.0
 
 - Improve Platforms' models [@f-meloni][] - [#259](https://github.com/danger/swift/pull/259)

--- a/Sources/DangerShellExecutor/ShellExecutor.swift
+++ b/Sources/DangerShellExecutor/ShellExecutor.swift
@@ -120,7 +120,7 @@ public struct ShellExecutor: ShellExecuting {
         let processEnv = ProcessInfo.processInfo.environment
         let task = Process()
         task.launchPath = processEnv["SHELL"]
-        task.arguments = ["-l", "-c", script]
+        task.arguments = ["-c", script]
         task.environment = mergeEnvs(localEnv: environmentVariables, processEnv: processEnv)
         task.currentDirectoryPath = FileManager.default.currentDirectoryPath
         return task


### PR DESCRIPTION
Currently `ShellExecutor` always invokes `$SHELL` with `-l` option but this causes unexpected reloading of .bash_profile, .zprofile, .bashrc, .zshrc and so on.

Basically `danger-swift` is designed as a command line tool and expected to run on login shell so `-l` option is unnecessary.

Especially, since .bash_profile or .zprofile is only loaded at login time, some people expects it to be loaded at only once in a login session.

Thus I removed `-l` option from `ShellExecutor`.