### PR TITLE
Use /bin/sh as command line interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## 2.0.2
 
 - Fix not to log in to shell twice [@manicmaniac][] - [#264](https://github.com/danger/swift/pull/264)
+- Use /bin/sh as command line interpreter [@manicmaniac][] - [#265](https://github.com/danger/swift/pull/265)
 
 ## 2.0.0
 

--- a/Sources/DangerShellExecutor/ShellExecutor.swift
+++ b/Sources/DangerShellExecutor/ShellExecutor.swift
@@ -117,11 +117,10 @@ public struct ShellExecutor: ShellExecuting {
         }
 
         let script = "\(command) \(arguments.joined(separator: " "))" + scriptOutputFile
-        let processEnv = ProcessInfo.processInfo.environment
         let task = Process()
-        task.launchPath = processEnv["SHELL"]
+        task.launchPath = "/bin/sh"
         task.arguments = ["-c", script]
-        task.environment = mergeEnvs(localEnv: environmentVariables, processEnv: processEnv)
+        task.environment = mergeEnvs(localEnv: environmentVariables, processEnv: ProcessInfo.processInfo.environment)
         task.currentDirectoryPath = FileManager.default.currentDirectoryPath
         return task
     }


### PR DESCRIPTION
`ShellExecutor` considers `$SHELL` environment variable to decide which shell should be used.
Actually POSIX permits to set `$SHELL` to any kind of command line interpreter even it doesn't conform to the specification for shell command interpreter.

> https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
> SHELL
> This variable shall represent a pathname of the user's preferred command language interpreter. If this interpreter does not conform to the Shell Command Language in the Shell and Utilities volume of IEEE Std 1003.1-2001, Chapter 2, Shell Command Language, utilities may behave differently from those described in IEEE Std 1003.1-2001.

Potentially users even can do `sudo chsh -s /usr/bin/python` and in that case, `danger-swift` doesn't work properly.

Therefore I changed `ShellExecutor` not to depend on the environment variable but just use POSIX standard `/bin/sh`.
`/bin/sh` is guaranteed to be there and it must be a bsh-compatible shell script language interpreter.

> https://pubs.opengroup.org/onlinepubs/7908799/xcu/sh.html