### PR TITLE
Remove Swiftlint from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,9 @@ LABEL "com.github.actions.description"="Runs Swift Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
-ARG SWIFT_LINT_VER=0.30.1
-
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
 RUN apt-get install -y nodejs
-
-# install SwiftLint
-RUN git clone -b $SWIFT_LINT_VER --single-branch --depth 1 https://github.com/realm/SwiftLint.git _SwiftLint
-RUN cd _SwiftLint && git submodule update --init --recursive; make install
 
 # Install danger-swift globally
 RUN git clone https://github.com/danger/danger-swift.git _danger-swift


### PR DESCRIPTION
Danger-Swift takes quite a lot when runs on GitHub Actions
<img width="1329" alt="Schermata 2019-09-06 alle 22 48 12" src="https://user-images.githubusercontent.com/17830956/64462563-c52c6a80-d0f8-11e9-8822-165f184bffc9.png">
Approximately more than half of that time it to clone swiftlint, that not everyone uses, and someone uses from SPM.