### PR TITLE
Update Marathon to a revision that supports swift 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Update Marathon to a revision that supports swift 5.1 [@f-meloni][] - [#271](https://github.com/danger/swift/pull/271)
 - Optimise danger actions clone [@f-meloni][] - [#270](https://github.com/danger/swift/pull/270)
 - Use `command -v` instead of `which` [@f-meloni][] - [#269](https://github.com/danger/swift/pull/269)
 - Remove swiftlint install commands from Dockerfile [@f-meloni][] - [#268](https://github.com/danger/swift/pull/268)

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Marathon",
         "state": {
           "branch": null,
-          "revision": "582505bbd8e782c7d8812f4c6d356ad19d5222a8",
-          "version": "3.2.0"
+          "revision": "79f0561a6d31b22f1f6d87ef4c8ddae6cf39aec5",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/shibapm/Logger", from: "0.1.0"),
-        .package(url: "https://github.com/JohnSundell/Marathon", from: "3.2.0"),
+        .package(url: "https://github.com/JohnSundell/Marathon", .revision("79f0561a6d31b22f1f6d87ef4c8ddae6cf39aec5")),
         .package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.9.0"),
         // Danger Plugins
         // Dev dependencies


### PR DESCRIPTION
Marathon is deprecated, and there is no release for https://github.com/JohnSundell/Marathon/pull/209, then I'm ok for us pointing the commit with the fix until Marathon is not replaced