### PR TITLE
Add Mint on the README as possibility to install Danger

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ npm install -g danger
 danger-swift ci
 ```
 
+Mint
+
+```
+mint install danger/swift
+```
+
 With Docker support ready for GitHub Actions.
 
 #### Local compiled danger-js


### PR DESCRIPTION
Is nice to give an additional possibility to install danger, given brew only allows you to install the last released version, mint allows you to specify which one you want and uses SPM to install it