### PR TITLE
Fix for inline empty Dictionary: Bitbucket Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Protect bitbucket cloud inline comment empty dictionary, as well as the to optional [@khoogheem][] - [#280](https://github.com/danger/swift/pull/280)
+
 ## 2.0.5
 
 - Make bitbucket cloud inline comment from optional [@f-meloni][] - [#278](https://github.com/danger/swift/pull/278)
@@ -353,3 +355,4 @@ This release also includes:
 [@mollyIV]: https://github.com/mollyIV
 [@smalljd]: https://github.com/smalljd
 [@manicmaniac]: https://github.com/manicmaniac
+[@khoogheem]: https://github.com/khoogheem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-- Protect bitbucket cloud inline comment empty dictionary, as well as the to optional [@khoogheem][] - [#280](https://github.com/danger/swift/pull/280)
+- Protect bitbucket cloud inline comment with all options being optional [@khoogheem][] - [#280](https://github.com/danger/swift/pull/280)
 
 ## 2.0.5
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -193,7 +193,7 @@ extension BitBucketCloud {
     public struct Comment: Decodable, Equatable {
         public struct Inline: Decodable, Equatable {
             public let from: Int?
-            public let to: Int // swiftlint:disable:this identifier_name
+            public let to: Int? // swiftlint:disable:this identifier_name
             public let path: String
         }
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -228,6 +228,22 @@ extension BitBucketCloud {
 
         /// The user that created the comment
         public let user: User
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.content = try container.decode(Content.self, forKey: .content)
+            self.createdOn = try container.decode(Date.self, forKey: .createdOn)
+            self.deleted = try container.decode(Bool.self, forKey: .deleted)
+            self.id = try container.decode(Int.self, forKey: .id)
+            // protect from "inline": {}
+            self.inline = (try? container.decodeIfPresent(Inline.self, forKey: .inline)) ?? nil
+            self.type = try container.decode(String.self, forKey: .type)
+            self.updatedOn = try container.decode(Date.self, forKey: .updatedOn)
+            self.user = try container.decode(User.self, forKey: .user)
+            
+        }
+
     }
 }
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -194,7 +194,7 @@ extension BitBucketCloud {
         public struct Inline: Decodable, Equatable {
             public let from: Int?
             public let to: Int? // swiftlint:disable:this identifier_name
-            public let path: String
+            public let path: String?
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -228,22 +228,6 @@ extension BitBucketCloud {
 
         /// The user that created the comment
         public let user: User
-        
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            
-            self.content = try container.decode(Content.self, forKey: .content)
-            self.createdOn = try container.decode(Date.self, forKey: .createdOn)
-            self.deleted = try container.decode(Bool.self, forKey: .deleted)
-            self.id = try container.decode(Int.self, forKey: .id)
-            // protect from "inline": {}
-            self.inline = (try? container.decodeIfPresent(Inline.self, forKey: .inline)) ?? nil
-            self.type = try container.decode(String.self, forKey: .type)
-            self.updatedOn = try container.decode(Date.self, forKey: .updatedOn)
-            self.user = try container.decode(User.self, forKey: .user)
-            
-        }
-
     }
 }
 


### PR DESCRIPTION
This fixes the issue where the json payload for the Comment can have inline as an empty dictionary:

```
            "inline" : {

            },
```

vs

```
            "inline" : {
            "to" : null,
            "path" : "client\/XXX\/Info.plist",
            "from" : 132
            },
```