### PR TITLE
Add an option to filter files and to disable quiet mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@
 
 ## Master
 
-- Danger dependencies resolver [@f-meloni][] - [#303](htts://github.com/danger/swift/pull/303)
-- Update swift toolchain to 5.0 [@f-meloni][] - [#307](htts://github.com/danger/swift/pull/307) 
-- Move to swift 5.1 [@f-meloni][] - [#275](htts://github.com/danger/swift/pull/275)
+- Danger dependencies resolver [@f-meloni][] - [#303](https://github.com/danger/swift/pull/303)
+- Update swift toolchain to 5.0 [@f-meloni][] - [#307](https://github.com/danger/swift/pull/307) 
+- Move to swift 5.1 [@f-meloni][] - [#275](https://github.com/danger/swift/pull/275)
+- Add an option to filter out files for SwiftLint [@avdlee][] - [#308](https://github.com/danger/swift/pull/308)
 
 ## 2.0.7
 
-- Use enums as namespace [@f-meloni][] - [#296](htts://github.com/danger/swift/pull/296) 
+- Use enums as namespace [@f-meloni][] - [#296](https://github.com/danger/swift/pull/296) 
 - Add error message when danger js is not installed [@f-meloni][] - [#295](https://github.com/danger/swift/pull/295)
 - Read standard error when the shell executor fails [@f-meloni][] - [#288](https://github.com/danger/swift/pull/288)
 - Add --version support [@f-meloni][] - [#287](https://github.com/danger/swift/pull/287)
@@ -371,3 +372,4 @@ This release also includes:
 [@manicmaniac]: https://github.com/manicmaniac
 [@khoogheem]: https://github.com/khoogheem
 [@fortmarek]: https://github.com/danger/swift/pull/283
+[@avdlee]: https://github.com/AvdLee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Danger dependencies resolver [@f-meloni][] - [#303](https://github.com/danger/swift/pull/303)
 - Update swift toolchain to 5.0 [@f-meloni][] - [#307](https://github.com/danger/swift/pull/307) 
 - Move to swift 5.1 [@f-meloni][] - [#275](https://github.com/danger/swift/pull/275)
-- Add an option to filter out files for SwiftLint [@avdlee][] - [#308](https://github.com/danger/swift/pull/308)
+- Add a new `LintStyle` enum to be able to also lint a specific set of files with SwiftLint [@avdlee][] - [#308](https://github.com/danger/swift/pull/308)
 
 ## 2.0.7
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,7 +20,7 @@ if !swiftFilesWithCopyright.isEmpty {
     warn("In Danger JS we don't include copyright headers, found them in: \(files)")
 }
 
-SwiftLint.lint(inline: true, directory: "Sources")
+SwiftLint.lint(.modifiedAndCreatedFiles(directory: "Sources"), inline: true)
 
 // Support running via `danger local`
 if danger.github != nil {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [
         .library(name: "Danger", type: .dynamic, targets: ["Danger"]),
         .library(name: "DangerFixtures", type: .dynamic, targets: ["DangerFixtures"]),
-        .library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"]), // dev
+        //.library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"]), // dev
         .executable(name: "danger-swift", targets: ["Runner"]),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [
         .library(name: "Danger", type: .dynamic, targets: ["Danger"]),
         .library(name: "DangerFixtures", type: .dynamic, targets: ["DangerFixtures"]),
-        //.library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"]), // dev
+        .library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"]), // dev
         .executable(name: "danger-swift", targets: ["Runner"]),
     ],
     dependencies: [

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -6,7 +6,7 @@ import Foundation
 public enum SwiftLint {
     public enum LintStyle {
         case all(directory: String?)
-        case modifiedFiles(directory: String?)
+        case modifiedAndCreatedFiles(directory: String?)
         case files([File])
     }
 
@@ -23,7 +23,7 @@ public enum SwiftLint {
                             quiet: Bool = true,
                             lintAllFiles: Bool = false,
                             swiftlintPath: String? = nil) -> [SwiftLintViolation] {
-        let lintStyle: LintStyle = lintAllFiles ? .all(directory: directory) : .modifiedFiles(directory: directory)
+        let lintStyle: LintStyle = lintAllFiles ? .all(directory: directory) : .modifiedAndCreatedFiles(directory: directory)
         return lint(lintStyle,
                     inline: inline,
                     configFile: configFile,
@@ -39,7 +39,7 @@ public enum SwiftLint {
     /// it uses by default swift run swiftlint if the Package.swift contains swiftlint as dependency,
     /// otherwise calls directly the swiftlint command
     @discardableResult
-    public static func lint(_ lintStyle: LintStyle = .modifiedFiles(directory: nil),
+    public static func lint(_ lintStyle: LintStyle = .modifiedAndCreatedFiles(directory: nil),
                             inline: Bool = false,
                             configFile: String? = nil,
                             strict: Bool = false,
@@ -105,7 +105,7 @@ extension SwiftLint {
                                  outputFilePath: outputFilePath,
                                  failAction: failAction,
                                  readFile: readFile)
-        case .modifiedFiles(let directory):
+        case .modifiedAndCreatedFiles(let directory):
             // Gathers modified+created files, invokes SwiftLint on each, and posts collected errors+warnings to Danger.
             var files = (danger.git.createdFiles + danger.git.modifiedFiles).filter { $0.fileType == .swift }
             if let directory = directory {

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -61,7 +61,7 @@ public enum SwiftLint {
 extension SwiftLint {
     // swiftlint:disable:next function_body_length
     static func lint(
-        lintStyle: LintStyle,
+        lintStyle: LintStyle = .modifiedAndCreatedFiles(directory: nil),
         danger: DangerDSL,
         shellExecutor: ShellExecuting,
         swiftlintPath: String,

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -39,7 +39,6 @@ public enum SwiftLint {
                     configFile: configFile,
                     strict: strict,
                     quiet: quiet,
-                    lintAllFiles: lintAllFiles,
                     swiftlintPath: swiftlintPath)
     }
 
@@ -54,7 +53,6 @@ public enum SwiftLint {
                             configFile: String? = nil,
                             strict: Bool = false,
                             quiet: Bool = true,
-                            lintAllFiles: Bool = false,
                             swiftlintPath: String? = nil) -> [SwiftLintViolation] {
         lint(lintStyle: lintStyle,
              danger: danger,

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -5,8 +5,18 @@ import Foundation
 /// it usable out of the box.
 public enum SwiftLint {
     public enum LintStyle {
+        /// Lints all the files instead of only the modified and created files.
+        /// - Parameters:
+        ///   - directory: Optional property to set the --path to execute at.
         case all(directory: String?)
+
+        /// Only lints the modified and created files with `.swift` extension.
+        /// - Parameters:
+        ///   - directory: Optional property to set the --path to execute at.
         case modifiedAndCreatedFiles(directory: String?)
+
+        /// Lints only the given files. This can be useful to do some manual filtering.
+        /// The files will be filtered on `.swift` only.
         case files([File])
     }
 
@@ -107,7 +117,7 @@ extension SwiftLint {
                                  readFile: readFile)
         case .modifiedAndCreatedFiles(let directory):
             // Gathers modified+created files, invokes SwiftLint on each, and posts collected errors+warnings to Danger.
-            var files = (danger.git.createdFiles + danger.git.modifiedFiles).filter { $0.fileType == .swift }
+            var files = (danger.git.createdFiles + danger.git.modifiedFiles)
             if let directory = directory {
                 files = files.filter { $0.hasPrefix(directory) }
             }
@@ -205,6 +215,8 @@ extension SwiftLint {
                                   failAction: (String) -> Void,
                                   readFile: (String) -> String) -> [SwiftLintViolation] {
 
+        let files = files.filter { $0.fileType == .swift }
+        
         // Only run Swiftlint, if there are files to lint
         guard !files.isEmpty else {
             return []

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -302,6 +302,28 @@ final class DangerSwiftLintTests: XCTestCase {
         XCTAssertEqual(swiftlintCommands.first!.environmentVariables, ["SCRIPT_INPUT_FILE_COUNT": "1", "SCRIPT_INPUT_FILE_0": "Harvey/SomeOtherFile.swift"])
     }
 
+    func testSpecificFilesSwiftOnlyFilter() {
+        let modified = [
+            "Tests/SomeFile.swift",
+            "Harvey/SomeOtherFile.swift",
+            "ExampleTests.swift",
+            "circle.yml",
+        ]
+        danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
+
+        _ = SwiftLint.lint(lintStyle: .files(["Harvey/SomeOtherFile.swift", "circle.yml"]),
+                           danger: danger,
+                           shellExecutor: executor,
+                           swiftlintPath: "swiftlint",
+                           currentPathProvider: fakePathProvider,
+                           outputFilePath: "swiftlintReport.json",
+                           readFile: mockedEmptyJSON)
+
+        let swiftlintCommands = executor.invocations.filter { $0.command == "swiftlint" }
+        XCTAssertEqual(swiftlintCommands.count, 1)
+        XCTAssertEqual(swiftlintCommands.first!.environmentVariables, ["SCRIPT_INPUT_FILE_COUNT": "1", "SCRIPT_INPUT_FILE_0": "Harvey/SomeOtherFile.swift"])
+    }
+
     func testPrintsNoMarkdownIfNoViolations() {
         _ = SwiftLint.lint(danger: danger,
                            shellExecutor: executor,
@@ -437,7 +459,8 @@ final class DangerSwiftLintTests: XCTestCase {
         ("testQuotesPathArguments", testQuotesPathArguments),
         ("testExecutesVerboseIfNotQuiet", testExecutesVerboseIfNotQuiet),
         ("testExecutesQuiet", testExecutesQuiet),
-        ("testFileFilter", testSpecificFilesLintStyle)
+        ("testSpecificFilesLintStyle", testSpecificFilesLintStyle),
+        ("testSpecificFilesSwiftOnlyFilter", testSpecificFilesSwiftOnlyFilter)
     ]
 }
 

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -184,11 +184,11 @@ final class DangerSwiftLintTests: XCTestCase {
     func testSendsOuputFileToTheExecutorWhenLintingAllTheFiles() {
         let configFile = "/Path/to/config/.swiftlint.yml"
 
-        _ = SwiftLint.lint(danger: danger,
+        _ = SwiftLint.lint(lintStyle: .all(directory: nil),
+                           danger: danger,
                            shellExecutor: executor,
                            swiftlintPath: "swiftlint",
                            configFile: configFile,
-                           lintAllFiles: true,
                            currentPathProvider: fakePathProvider,
                            outputFilePath: "swiftlintReport.json",
                            readFile: mockedEmptyJSON)
@@ -206,10 +206,10 @@ final class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger,
+        _ = SwiftLint.lint(lintStyle: .modifiedAndCreatedFiles(directory: directory),
+                           danger: danger,
                            shellExecutor: executor,
                            swiftlintPath: "swiftlint",
-                           directory: directory,
                            currentPathProvider: fakePathProvider,
                            outputFilePath: "swiftlintReport.json",
                            readFile: mockedEmptyJSON)
@@ -228,10 +228,10 @@ final class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger,
+        _ = SwiftLint.lint(lintStyle: .all(directory: nil),
+                           danger: danger,
                            shellExecutor: executor,
                            swiftlintPath: "swiftlint",
-                           lintAllFiles: true,
                            currentPathProvider: fakePathProvider,
                            outputFilePath: "swiftlintReport.json",
                            readFile: mockedEmptyJSON)
@@ -251,11 +251,10 @@ final class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger,
+        _ = SwiftLint.lint(lintStyle: .all(directory: directory),
+                           danger: danger,
                            shellExecutor: executor,
                            swiftlintPath: "swiftlint",
-                           directory: directory,
-                           lintAllFiles: true,
                            currentPathProvider: fakePathProvider,
                            outputFilePath: "swiftlintReport.json",
                            readFile: mockedEmptyJSON)
@@ -281,24 +280,7 @@ final class DangerSwiftLintTests: XCTestCase {
         XCTAssertEqual(filesExtensions, ["swift"])
     }
 
-    func testFailsWithFilterAndAllFiles() {
-        var failedMessage: String?
-        let failAction: (String) -> Void = { failedMessage = $0 }
-
-        _ = SwiftLint.lint(danger: danger,
-                           shellExecutor: executor,
-                           swiftlintPath: "swiftlint",
-                           inline: true,
-                           lintAllFiles: true,
-                           filesFilter: { _ in true },
-                           currentPathProvider: fakePathProvider,
-                           outputFilePath: "swiftlintReport.json",
-                           failAction: failAction,
-                           readFile: mockedViolationJSON)
-        XCTAssertEqual(failedMessage, "You can't use a files filter when lintAllFiles is set to `true`.")
-    }
-
-    func testFileFilter() {
+    func testSpecificFilesLintStyle() {
         let modified = [
             "Tests/SomeFile.swift",
             "Harvey/SomeOtherFile.swift",
@@ -307,12 +289,10 @@ final class DangerSwiftLintTests: XCTestCase {
         ]
         danger = githubWithFilesDSL(created: [], modified: modified, deleted: [], fileMap: [:])
 
-        _ = SwiftLint.lint(danger: danger,
+        _ = SwiftLint.lint(lintStyle: .files(["Harvey/SomeOtherFile.swift"]),
+                           danger: danger,
                            shellExecutor: executor,
                            swiftlintPath: "swiftlint",
-                           filesFilter: { file in
-                                return !file.contains("Tests")
-                           },
                            currentPathProvider: fakePathProvider,
                            outputFilePath: "swiftlintReport.json",
                            readFile: mockedEmptyJSON)
@@ -457,8 +437,7 @@ final class DangerSwiftLintTests: XCTestCase {
         ("testQuotesPathArguments", testQuotesPathArguments),
         ("testExecutesVerboseIfNotQuiet", testExecutesVerboseIfNotQuiet),
         ("testExecutesQuiet", testExecutesQuiet),
-        ("testFileFilter", testFileFilter),
-        ("testFailsWithFilterAndAllFiles", testFailsWithFilterAndAllFiles)
+        ("testFileFilter", testSpecificFilesLintStyle)
     ]
 }
 


### PR DESCRIPTION
This PR adds two new features. The first one enables a files filter that can be used as follows:

```swift
SwiftLint.lint(inline: true, configFile: "\(pwd)/Submodules/WeTransfer-iOS-CI/SwiftLint/.swiftlint-tests.yml", quiet: true, filesFilter: { file -> Bool in
    return file.lowercased().contains("test")
})
```

It allows us to use a specific config file for certain files only. I've decided to implement it this way as the excluded paths are not respected by Danger-SwiftLint. The Ruby version we've been using before does something similar as you can see [here](https://github.com/ashfurrow/danger-ruby-swiftlint/blob/master/lib/danger_plugin.rb#L229). We needed the same as we migrate to Danger-Swift.

To debug this new feature I decided to also add an option to disable the `--quiet` argument. This can be useful for debugging purposes to see whether the used configurations are respected:

```bash
Loading configuration from '/Users/antoinevanderlee/Documents/GIT-Projects/WeTransfer/Coyote/Submodules/WeTransfer-iOS-CI/SwiftLint/.swiftlint-source.yml'

Linting 'ContentUploadInfoList.swift' (1/2)
Linting 'ChunksCreationOperation.swift' (2/2)

Done linting! Found 1 violation, 1 serious in 2 files.

Loading configuration from '/Users/antoinevanderlee/Documents/GIT-Projects/WeTransfer/Coyote/Submodules/WeTransfer-iOS-CI/SwiftLint/.swiftlint-tests.yml'

Linting 'ChunksCreationOperationTests.swift' (1/1)

Done linting! Found 0 violations, 0 serious in 1 file.
```