### PR TITLE
Add top-level properties for child DSLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add top-level properties for child DSLs [@417-72KI][] - [#314](https://github.com/danger/swift/pull/314)
+
 ## 3.0.0
 
 - Danger dependencies manager [@f-meloni][] - [#303](https://github.com/danger/swift/pull/303)

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -244,3 +244,7 @@ extension BitBucketCloud {
         public let comment: Comment?
     }
 }
+
+public var bitbucketCloud: BitBucketCloud! {
+    return DangerRunner.shared.dsl.bitbucketCloud
+}

--- a/Sources/Danger/BitBucketServerDSL.swift
+++ b/Sources/Danger/BitBucketServerDSL.swift
@@ -395,3 +395,7 @@ extension BitBucketServer {
         public let type: String?
     }
 }
+
+public var bitbucketServer: BitBucketServer! {
+    return DangerRunner.shared.dsl.bitbucketServer
+}

--- a/Sources/Danger/DangerUtils.swift
+++ b/Sources/Danger/DangerUtils.swift
@@ -82,3 +82,7 @@ public struct DangerUtils {
         return try shellExecutor.spawn(command, arguments: arguments)
     }
 }
+
+public var utils: DangerUtils {
+    return DangerRunner.shared.dsl.utils
+}

--- a/Sources/Danger/GitDSL.swift
+++ b/Sources/Danger/GitDSL.swift
@@ -54,3 +54,7 @@ extension Git {
         public let url: String
     }
 }
+
+public var git: Git {
+    return DangerRunner.shared.dsl.git
+}

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -460,3 +460,7 @@ extension GitHub {
         public let dueOn: Date?
     }
 }
+
+public var github: GitHub! {
+    return DangerRunner.shared.dsl.github
+}

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -235,3 +235,7 @@ extension GitLab {
         public let webUrl: String
     }
 }
+
+public var gitLab: GitLab! {
+    return DangerRunner.shared.dsl.gitLab
+}


### PR DESCRIPTION
There are top-level functions for reporting(e.g. `warn`, `fail`).
I think it would be nicer that there will be also properties for DSLs(e.g. `git`, `github`)

## Example 
- before
```swift
let danger = Danger()
if danger.github.pullRequest.title.lowercased().contains("[wip]") { // ← Redundant `danger` calling.
    warn("PR is classed as Work in Progress") // ← Already in top-level
}
```

- after
```swift
if github.pullRequest.title.lowercased().contains("[wip]") { // ← No more `danger` variable!
    warn("PR is classed as Work in Progress")
}
```