### PR TITLE
fix: update Makefile to copy third party libraries recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install: build
 	mkdir -p $(PREFIX)/bin
 	mkdir -p $(LIB_INSTALL_PATH)
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
-	cp -f $(SWIFT_LIB_FILES) $(LIB_INSTALL_PATH)
+	cp -fr $(SWIFT_LIB_FILES) $(LIB_INSTALL_PATH)
 
 build:
 	swift package clean


### PR DESCRIPTION
When using install with homebrew we got this error:

```bash
Last 15 lines from /Users/lucaspaim/Library/Logs/Homebrew/danger-swift/01.make:
[5/10] Compiling RunnerLib CliArgs.swift
[6/10] Compiling DangerDependenciesResolver Data+Encoding.swift
[7/11] Compiling Runner Edit.swift
[8/11] Linking danger-swift
[9/11] Compiling OctoKit Configuration.swift
[10/12] Compiling Danger BitBucketCloud.swift
[11/13] Linking libDanger.dylib
[12/13] Compiling DangerFixtures CustomGitHubDSL.swift
[13/13] Linking libDangerFixtures.dylib
mkdir -p /usr/local/Cellar/danger-swift/3.2.0/bin
mkdir -p /usr/local/Cellar/danger-swift/3.2.0/lib/danger
cp -f .build/release/danger-swift /usr/local/Cellar/danger-swift/3.2.0/bin/danger-swift
cp -f .build/release/libDanger.* .build/release/Danger.swiftdoc .build/release/Danger.swiftmodule .build/release/OctoKit.swiftdoc .build/release/OctoKit.swiftmodule .build/release/RequestKit.swiftdoc .build/release/RequestKit.swiftmodule .build/release/Logger.swiftdoc .build/release/Logger.swiftmodule .build/release/DangerShellExecutor.swiftdoc .build/release/DangerShellExecutor.swiftmodule /usr/local/Cellar/danger-swift/3.2.0/lib/danger
cp: .build/release/libDanger.dylib.dSYM is a directory (not copied).
make: *** [install] Error 1
```

This PR fixes it