### PR TITLE
fix/fix-broken-edit

### DIFF
--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -233,6 +233,6 @@ extension String {
     var onlyNumbersAndDots: String? {
         var charset = CharacterSet.decimalDigits
         charset.insert(".")
-        return String(unicodeScalars.filter { charset.contains($0) })
+        return String(unicodeScalars.filter(charset.contains))
     }
 }

--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -231,8 +231,8 @@ extension String {
     }
 
     var onlyNumbersAndDots: String? {
-        guard let regex = try? NSRegularExpression(pattern: "[^0-9.]", options: .caseInsensitive) else { return nil }
-        return regex.stringByReplacingMatches(in: self, options: .withTransparentBounds,
-                                              range: NSRange(location: 0, length: count), withTemplate: "")
+        var charset = CharacterSet.decimalDigits
+        charset.insert(".")
+        return String(unicodeScalars.filter { charset.contains($0) })
     }
 }

--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -171,7 +171,7 @@ public struct PackageManager {
                                                              onFolder: folder,
                                                              arguments: ["--version"],
                                                              executor: executor)
-        versionString = versionString?.components(separatedBy: " (swiftpm").first?.onlyNumbersAndDots
+        versionString = versionString?.onlyNumbersAndDots
         return Version(versionString ?? "") ?? .null
     }
 }

--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -171,15 +171,7 @@ public struct PackageManager {
                                                              onFolder: folder,
                                                              arguments: ["--version"],
                                                              executor: executor)
-        versionString = versionString?.components(separatedBy: " (swiftpm").first
-        versionString = versionString?.deletingPrefix("Apple Swift Package Manager - Swift ")
-
-        let versionComponents = versionString?.components(separatedBy: ".") ?? []
-
-        if versionComponents.count > 2 {
-            versionString = "\(versionComponents[0]).\(versionComponents[1]).\(versionComponents[2])"
-        }
-
+        versionString = versionString?.components(separatedBy: " (swiftpm").first?.onlyNumbersAndDots
         return Version(versionString ?? "") ?? .null
     }
 }
@@ -236,5 +228,11 @@ extension String {
     fileprivate func deletingPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         return String(dropFirst(prefix.count))
+    }
+
+    var onlyNumbersAndDots: String? {
+        guard let regex = try? NSRegularExpression(pattern: "[^0-9.]", options: .caseInsensitive) else { return nil }
+        return regex.stringByReplacingMatches(in: self, options: .withTransparentBounds,
+                                              range: NSRange(location: 0, length: count), withTemplate: "")
     }
 }


### PR DESCRIPTION
In my computer using the last one xcode on a mac os Catalina, I can't use the `danger-swift edit` because it's generate a wrong swift tools version.

This is because the function `resolveSwiftToolsVersion` only remove the prefix: "Apple Swift Package Manager - Swift ", but in my computer the command `swift package --version` get an output:

```bash
Swift Package Manager - Swift 5.2.0
```

Without the "Apple " prefix, because this I got an error like this:
```
ERROR: commandFailed(command: "<.....>Dangerfile\' is using Swift tools version 0.0.0 which is no longer supported; consider using \'// swift-tools-version:5.2\' to specify the current tools version\n")
```

Using the new `onlyNumbersAndDots` extension, it's a more safe form to extract the version of swift package manager. 