### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ public struct DangerPlugin {
 
 You can use Swift PM to install both `danger-swift` and your plugins:
 
+- Install Danger JS
+
+  ```bash
+  $ npm install -g danger
+  ```
+
 - Add to your `Package.swift`:
 
   ```swift


### PR DESCRIPTION
To avoid confusions related to the dependency of Danger JS  and be sure the user knows that they have to install Danger JS  to be able to run swift-danger with SwiftPM

Related to #336 