### PR TITLE
Fixing Bitbucket cloud optional user issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+- Update BitBucketCloud commit user to be optional [@mahmoud-amer-m](https://github.com/mahmoud-amer-m) - [#355](https://github.com/danger/swift/pull/355)
+
+## Master
+
 - Update Dockerfile to use swift 5.2 [@f-meloni][] - [#330](https://github.com/danger/swift/pull/330)
 - Add GitHub draft support[@captainbarbosa][] - [#341](https://github.com/danger/swift/pull/341)
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -55,7 +55,7 @@ extension BitBucketCloud {
             public let role: Role
 
             /// The user who participated in this PR
-            public let user: User
+            public let user: User?
         }
 
         /// The creator of the PR
@@ -167,7 +167,7 @@ extension BitBucketCloud {
             let raw: String
 
             /// The user that created the commit
-            let user: User
+            let user: User?
         }
 
         public struct Parent {
@@ -227,7 +227,7 @@ extension BitBucketCloud {
         public let updatedOn: Date
 
         /// The user that created the comment
-        public let user: User
+        public let user: User?
     }
 }
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -55,7 +55,7 @@ extension BitBucketCloud {
             public let role: Role
 
             /// The user who participated in this PR
-            public let user: User?
+            public let user: User
         }
 
         /// The creator of the PR
@@ -227,7 +227,7 @@ extension BitBucketCloud {
         public let updatedOn: Date
 
         /// The user that created the comment
-        public let user: User?
+        public let user: User
     }
 }
 

--- a/Tests/DangerTests/BitBucketCloudTests.swift
+++ b/Tests/DangerTests/BitBucketCloudTests.swift
@@ -63,7 +63,7 @@ final class BitBucketCloudTests: XCTestCase {
     func testCommitWithoutUser() {
         do {
             let commit = try JSONDecoder().decode(BitBucketCloud.Commit.self, from: Data(BitBucketCloudCommitWithoutUser.utf8))
-            XCTAssertEqual(commit.author.raw, "foo@bar.com")
+            XCTAssertEqual(commit.author.raw, "Franco Meloni <franco.meloni91@gmail.com>")
             XCTAssertNil(commit.author.user)
         } catch {
             XCTFail("Couldn't parse JSON commit (BitBucketCloudCommitWithoutUser) in BitbucketCloudCommit. \nError: \(error)")

--- a/Tests/DangerTests/BitBucketCloudTests.swift
+++ b/Tests/DangerTests/BitBucketCloudTests.swift
@@ -59,6 +59,16 @@ final class BitBucketCloudTests: XCTestCase {
             ),
         ])
     }
+    
+    func testCommitWithoutUser() {
+        do {
+            let commit = try JSONDecoder().decode(BitBucketCloud.Commit.self, from: Data(BitBucketCloudCommitWithoutUser.utf8))
+            XCTAssertEqual(commit.author.raw, "foo@bar.com")
+            XCTAssertNil(commit.author.user)
+        } catch {
+            XCTFail("Couldn't parse JSON commit (BitBucketCloudCommitWithoutUser) in BitbucketCloudCommit. \nError: \(error)")
+        }
+    }
 
     func testParsesMetadata() {
         let metadata = bitbucketCould.metadata

--- a/Tests/DangerTests/BitbucketCloudResources/BitbucketCloudCommit.swift
+++ b/Tests/DangerTests/BitbucketCloudResources/BitbucketCloudCommit.swift
@@ -1,0 +1,10 @@
+public let BitBucketCloudCommitWithoutUser = """
+{
+    "author":{
+        "raw": "Franco Meloni <franco.meloni91@gmail.com>"
+    },
+    "date":1223322,
+    "hash":"9ab48765728b309d88486a52bb57805fffe20410",
+    "message": "README.md edited online with Bitbucket"
+}
+"""


### PR DESCRIPTION
referencing, [Issue #28 ](https://github.com/danger/swift/issues/354), Bitbucket cloud always fails with error:
`ERROR: Failed to parse JSON: keyNotFound(CodingKeys(stringValue: "user", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "danger", intValue: nil), CodingKeys(stringValue: "bitbucket_cloud", intValue: nil), CodingKeys(stringValue: "commits", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "author", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"user\", intValue: nil) (\"user\").", underlyingError: nil)) ERROR: Dangerfile eval failed at Dangerfile.swift ERROR: Could not get the results JSON file at /var/folders/6q/wgy6jtp12w5gzgm9lzcglpqw0000gn/T/danger-response.json
`
 This PR introduces optional user variable in case the commit email isn't assigned to a bitbucket user