### PR TITLE
Run a Dangerfile using Danger dependencies resolver in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       script:
         - mkdir Test
         - mv DangerfileWithDependencies.swift Test
-        - cd Test && danger-swift ci
+        - cd Test && danger-swift ci --dangerfile DangerfileWithDependencies.swift
 
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,19 @@ matrix:
         - DEBUG="*" danger-swift ci
 
     - os: osx
+      osx_image: xcode11.2
+      name: Danger Dependencies
+      install:
+        - node -v
+        - npm install -g danger
+        - make install
+      script:
+        - mkdir Test
+        - mv DangerfileWithDependencies.swift Test
+        - cd Test && danger-swift ci
+
+
+    - os: osx
       name: Danger with SPM
       osx_image: xcode11.2
       install:

--- a/DangerfileWithDependencies.swift
+++ b/DangerfileWithDependencies.swift
@@ -1,0 +1,4 @@
+import Danger
+import DangerXCodeSummary // package: https://github.com/f-meloni/danger-swift-xcodesummary.git
+
+let danger = Danger()


### PR DESCRIPTION
While we not have a built in resolver we always run the SPM configuration on CI, I added a simple Dangerfile that can run on CI and verify if the dependencies resolver is still working