### PR TITLE
Add dependency name when resolving for swift >= 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       script:
         - mkdir Test
         - mv DangerfileWithDependencies.swift Test
-        - cd Test && danger-swift ci --dangerfile DangerfileWithDependencies.swift
+        - cd Test && danger-swift ci --dangerfile DangerfileWithDependencies.swift --id Dependencies_Test
 
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         - DEBUG="*" danger-swift ci
 
     - os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.5
       name: Danger Dependencies
       install:
         - node -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add dependency name when resolving for swift >= 5.2 [@f-meloni][] - [#357](https://github.com/danger/swift/pull/357)
+
 ## 3.3.1
 
 - Search for danger-js binary before searching danger binary [@f-meloni][] - [#351](https://github.com/danger/swift/pull/351)

--- a/Sources/DangerDependenciesResolver/Package.swift
+++ b/Sources/DangerDependenciesResolver/Package.swift
@@ -8,8 +8,12 @@ public struct Package: Equatable, Codable {
 }
 
 extension Package {
-    var dependencyString: String {
-        ".package(url: \"\(url.absoluteString)\", from: \"\(majorVersion).0.0\")"
+    func dependencyString(forToolsVersion version: Version) -> String {
+        if version >= Version(major: 5, minor: 2, patch: 0) {
+            return #".package(name: "\#(name)", url: "\#(url.absoluteString)", from: "\#(majorVersion).0.0")"#
+        } else {
+            return #".package(url: "\#(url.absoluteString)", from: "\#(majorVersion).0.0")"#
+        }
     }
 }
 

--- a/Sources/DangerDependenciesResolver/PackageGenerator.swift
+++ b/Sources/DangerDependenciesResolver/PackageGenerator.swift
@@ -41,7 +41,7 @@ struct PackageGenerator {
                 description += ",\n"
             }
 
-            description.append("        \(package.dependencyString)")
+            description.append("        \(package.dependencyString(forToolsVersion: toolsVersion))")
         }
 
         description.append("\n    ],\n")

--- a/Tests/DangerDependenciesResolverTests/PackageGeneratorTests.swift
+++ b/Tests/DangerDependenciesResolverTests/PackageGeneratorTests.swift
@@ -33,6 +33,20 @@ final class PackageGeneratorTests: XCTestCase {
         assertSnapshot(matching: String(data: spyFileCreator.receivedContents!, encoding: .utf8)!, as: .lines)
     }
 
+    func testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2() throws {
+        let packageListMaker = StubbedPackageListMaker(packages: [
+            Package(name: "Dependency1", url: URL(string: "https://github.com/danger/dependency1")!, majorVersion: 1),
+            Package(name: "Dependency2", url: URL(string: "https://github.com/danger/dependency2")!, majorVersion: 2),
+            Package(name: "Dependency3", url: URL(string: "https://github.com/danger/dependency3")!, majorVersion: 3),
+        ])
+        let spyFileCreator = SpyFileCreator()
+        let generator = PackageGenerator(folder: "folder", generatedFolder: "generatedFolder", packageListMaker: packageListMaker, fileCreator: spyFileCreator)
+
+        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 2, 0))
+
+        assertSnapshot(matching: String(data: spyFileCreator.receivedContents!, encoding: .utf8)!, as: .lines)
+    }
+
     func testGeneratedDescriptionHeader() throws {
         let packageListMaker = StubbedPackageListMaker(packages: [])
         let spyFileCreator = SpyFileCreator()

--- a/Tests/DangerDependenciesResolverTests/XCTestManifests.swift
+++ b/Tests/DangerDependenciesResolverTests/XCTestManifests.swift
@@ -32,6 +32,7 @@
         static let __allTests__PackageGeneratorTests = [
             ("testGeneratedDescriptionHeader", testGeneratedDescriptionHeader),
             ("testGeneratedPackageWhenThereAreDependencies", testGeneratedPackageWhenThereAreDependencies),
+            ("testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2", testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2),
             ("testGeneratedPackageWhenThereAreNoDependencies", testGeneratedPackageWhenThereAreNoDependencies),
         ]
     }

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
@@ -1,0 +1,16 @@
+// swift-tools-version:5.2
+// danger-dependency-generator-version:1
+
+import PackageDescription
+
+let package = Package(
+    name: "PACKAGES",
+    products: [.library(name: "DangerDependencies", type: .dynamic, targets: ["PACKAGES"])],
+    dependencies: [
+        .package(name: "Dependency1", url: "https://github.com/danger/dependency1", from: "1.0.0"),
+        .package(name: "Dependency2", url: "https://github.com/danger/dependency2", from: "2.0.0"),
+        .package(name: "Dependency3", url: "https://github.com/danger/dependency3", from: "3.0.0")
+    ],
+    targets: [.target(name: "PACKAGES", dependencies: ["Dependency1", "Dependency2", "Dependency3"])],
+    swiftLanguageVersions: [.version("5")]
+)

--- a/Tests/DangerTests/BitBucketCloudTests.swift
+++ b/Tests/DangerTests/BitBucketCloudTests.swift
@@ -59,7 +59,7 @@ final class BitBucketCloudTests: XCTestCase {
             ),
         ])
     }
-    
+
     func testCommitWithoutUser() {
         do {
             let commit = try JSONDecoder().decode(BitBucketCloud.Commit.self, from: Data(BitBucketCloudCommitWithoutUser.utf8))

--- a/Tests/DangerTests/XCTestManifests.swift
+++ b/Tests/DangerTests/XCTestManifests.swift
@@ -6,6 +6,7 @@
         //   `swift test --generate-linuxmain`
         // to regenerate.
         static let __allTests__BitBucketCloudTests = [
+            ("testCommitWithoutUser", testCommitWithoutUser),
             ("testParsesActivities", testParsesActivities),
             ("testParsesComments", testParsesComments),
             ("testParsesCommits", testParsesCommits),


### PR DESCRIPTION
On the latest xcode you get 

```
dependency 'DangerSwiftProse' in target '_dangerfile_imports' requires explicit declaration; provide the name of the package dependency with '.package(name: "DangerSwiftProse", url: "https://github.com/f-meloni/danger-swift-prose.git", from: "1.0.0")'
```

when you try to resolve a dependency with the Danger dependencies resolver