### PR TITLE
Add Link Relations for GitHub PR 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add Link Relations for GitHub PR [@417-72KI][] - [#368](https://github.com/danger/swift/pull/368)
+
 ## 3.5.0
 
 - Add workaround for Xcode 12 [@f-meloni][] - [#372](https://github.com/danger/swift/pull/3672)

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -155,22 +155,30 @@ extension GitHub.PullRequest {
             case statuses
         }
 
+        public struct Relation: Decodable, Equatable, ExpressibleByStringLiteral {
+            public let href: String
+
+            public init(stringLiteral value: String) {
+                self.href = value
+            }
+        }
+
         /// The API location of the Pull Request.
-        public let `self`: String
+        public let `self`: Relation
         /// The HTML location of the Pull Request.
-        public let html: String
+        public let html: Relation
         /// The API location of the Pull Request's Issue.
-        public let issue: String
+        public let issue: Relation
         /// The API location of the Pull Request's Issue comments.
-        public let comments: String
+        public let comments: Relation
         /// The API location of the Pull Request's Review comments.
-        public let reviewComments: String
+        public let reviewComments: Relation
         /// The URL template to construct the API location for a Review comment in the Pull Request's repository.
-        public let reviewComment: String
+        public let reviewComment: Relation
         /// The API location of the Pull Request's commits.
-        public let commits: String
+        public let commits: Relation
         /// The API location of the Pull Request's commit statuses, which are the statuses of its head branch.
-        public let statuses: String
+        public let statuses: Relation
     }
 }
 

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -142,7 +142,10 @@ extension GitHub {
 }
 
 extension GitHub.PullRequest {
-    /// Pull Requests have these possible link relations
+    /// Pull Requests have possible link relations
+    ///
+    /// - See:
+    ///   [Reference](https://docs.github.com/en/rest/reference/pulls#link-relations)
     public struct Link: Decodable, Equatable {
         enum CodingKeys: String, CodingKey {
             case `self`

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -54,6 +54,7 @@ extension GitHub {
             case changedFiles = "changed_files"
             case htmlUrl = "html_url"
             case draft
+            case links = "_links"
         }
 
         public enum PullRequestState: String, Decodable {
@@ -134,6 +135,42 @@ extension GitHub {
 
         // The draft state of the pull request
         public let draft: Bool
+
+        /// Possible link relations
+        public let links: Link
+    }
+}
+
+extension GitHub.PullRequest {
+    /// Pull Requests have these possible link relations
+    public struct Link: Decodable, Equatable {
+        enum CodingKeys: String, CodingKey {
+            case `self`
+            case html
+            case issue
+            case comments
+            case reviewComments = "review_comments"
+            case reviewComment = "review_comment"
+            case commits
+            case statuses
+        }
+
+        /// The API location of the Pull Request.
+        public let `self`: String
+        /// The HTML location of the Pull Request.
+        public let html: String
+        /// The API location of the Pull Request's Issue.
+        public let issue: String
+        /// The API location of the Pull Request's Issue comments.
+        public let comments: String
+        /// The API location of the Pull Request's Review comments.
+        public let reviewComments: String
+        /// The URL template to construct the API location for a Review comment in the Pull Request's repository.
+        public let reviewComment: String
+        /// The API location of the Pull Request's commits.
+        public let commits: String
+        /// The API location of the Pull Request's commit statuses, which are the statuses of its head branch.
+        public let statuses: String
     }
 }
 

--- a/Tests/DangerTests/GitHubTests.swift
+++ b/Tests/DangerTests/GitHubTests.swift
@@ -337,7 +337,17 @@ final class GitHubTests: XCTestCase {
             changedFiles: nil,
             milestone: milestone,
             htmlUrl: "https://github.com/octocat/Hello-World/pull/1347",
-            draft: false
+            draft: false,
+            links: GitHub.PullRequest.Link(
+                self: "https://api.github.com/repos/octocat/Hello-World/pulls/1347",
+                html: "https://github.com/octocat/Hello-World/pull/1347",
+                issue: "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+                comments: "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments",
+                reviewComments: "https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments",
+                reviewComment: "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
+                commits: "https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits",
+                statuses: "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+            )
         )
 
         XCTAssertEqual(expectedPR, actualPR)


### PR DESCRIPTION
The Pull Request API on GitHub has `_links` key, here is a doc.
https://docs.github.com/en/rest/reference/pulls#link-relations

This PR may resolve #364 
