### PR TITLE
make SwiftLintViolation properties public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Add Link Relations for GitHub PR [@417-72KI][] - [#368](https://github.com/danger/swift/pull/368)
+- Make `SwiftLintViolation` properties public - [#377](https://github.com/danger/swift/pull/377)
 
 ## 3.5.0
 

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
@@ -4,11 +4,11 @@ public struct SwiftLintViolation: Decodable {
         case error = "Error"
     }
 
-    public var ruleID: String
-    public var reason: String
-    public var line: Int
-    public var severity: Severity
-    public var file: String
+    public internal(set) var ruleID: String
+    public internal(set) var reason: String
+    public internal(set) var line: Int
+    public internal(set) var severity: Severity
+    public internal(set) var file: String
 
     var messageText: String {
         reason + " (`\(ruleID)`)"

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLintViolation.swift
@@ -1,14 +1,14 @@
 public struct SwiftLintViolation: Decodable {
-    enum Severity: String, Decodable {
+    public enum Severity: String, Decodable {
         case warning = "Warning"
         case error = "Error"
     }
 
-    var ruleID: String
-    var reason: String
-    var line: Int
-    var severity: Severity
-    var file: String
+    public var ruleID: String
+    public var reason: String
+    public var line: Int
+    public var severity: Severity
+    public var file: String
 
     var messageText: String {
         reason + " (`\(ruleID)`)"


### PR DESCRIPTION
In our project, we use swiftlint to flag todos as warnings in addition to style warnings. For todos, we have a limit of ~10 before we want to block the build, while we don't want any style / compiler warnings allowed, so I'd like to write a danger rule like so:
```
let violations = SwiftLint.lint(.all(directory: nil))
let todosLimit = 10

let todos = violations.filter { $0.ruleID == "todo_rule" }
let warnings = violations.count - todos.count

if warnings.count > 0 {
    fail("Warning count exceeds \(warningsLimit) warnings")
}
if todos.count > todosLimit {
    fail("todo count exceeds \(todosLimit) todos")
}
```

but currently cannot as `ruleID` is marked `internal`