### PR TITLE
Make `draft` optional for some repos which Draft pull requests are not available in GitHub Pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Make `draft` optional for some repos which Draft pull requests are not available in GitHub Pulls [@417-72KI][] - [#378](https://github.com/danger/swift/pull/378)
 - Add Link Relations for GitHub PR [@417-72KI][] - [#368](https://github.com/danger/swift/pull/368)
 
 ## 3.5.0

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -134,7 +134,7 @@ extension GitHub {
         public let htmlUrl: String
 
         // The draft state of the pull request
-        public let draft: Bool
+        public let draft: Bool?
 
         /// Possible link relations
         public let links: Link

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -133,7 +133,7 @@ extension GitHub {
         /// The link back to this PR as user-facing
         public let htmlUrl: String
 
-        // The draft state of the pull request
+        /// The draft state of the pull request
         public let draft: Bool?
 
         /// Possible link relations


### PR DESCRIPTION
May resolve #376.

I'm not sure about actual specs but according to [this reference](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests), Draft PR is not available on some repositories and `draft` property may be null on this case.
