### PR TITLE
Fixing Bitbucket cloud optional user properties issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Release Docker image with SwiftLint [@f-meloni][] - [#380](https://github.com/danger/swift/pull/3680)
 - Add .swiftlint.yml [@417-72KI][] [#383](https://github.com/danger/swift/pull/383)
 - Resolve `superfluous_disable_command` [@417-72KI][] [#387](https://github.com/danger/swift/pull/387)
+- Make BitBucketCloud.User accountId and nickname optional [@abel3cl][] - [#388](https://github.com/danger/swift/pull/388)
 
 ## 3.6.1
 

--- a/Sources/Danger/BitBucketCloud.swift
+++ b/Sources/Danger/BitBucketCloud.swift
@@ -147,13 +147,13 @@ extension BitBucketCloud {
         }
 
         /// The acount id of the user
-        public let accountId: String
+        public let accountId: String?
 
         /// The display name of user
         public let displayName: String
 
         /// The nick name of the user
-        public let nickname: String
+        public let nickname: String?
 
         /// The uuid of the user
         public let uuid: String

--- a/Tests/DangerTests/BitBucketCloudTests.swift
+++ b/Tests/DangerTests/BitBucketCloudTests.swift
@@ -70,6 +70,18 @@ final class BitBucketCloudTests: XCTestCase {
         }
     }
 
+    func testCommentUserWithoutAccountId() {
+        do {
+            let comment = try JSONDecoder().decode(BitBucketCloud.Comment.self, from: Data(BitBucketCloudCommentUserWithoutAccountIdAndNickname.utf8))
+            XCTAssertEqual(comment.user.displayName, "Franco Meloni")
+            XCTAssertNil(comment.user.nickname)
+            XCTAssertEqual(comment.user.uuid, "{bd1991e4-a3ed-45b2-be38-acea659650f1}")
+            XCTAssertNil(comment.user.accountId)
+        } catch {
+            XCTFail("Couldn't parse JSON commit (BitBucketCloudCommentUserWithoutAccountId) in BitbucketCloudComment. \nError: \(error)")
+        }
+    }
+
     func testParsesMetadata() {
         let metadata = bitbucketCould.metadata
 

--- a/Tests/DangerTests/BitbucketCloudResources/BitbucketCloudCommentUserWithoutAccountIdAndNickname.swift
+++ b/Tests/DangerTests/BitbucketCloudResources/BitbucketCloudCommentUserWithoutAccountIdAndNickname.swift
@@ -1,0 +1,53 @@
+public let BitBucketCloudCommentUserWithoutAccountIdAndNickname = """
+{
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/Zagolo/danger-kotlin/pullrequests/1/comments/109197958"
+      },
+      "html": {
+        "href": "https://bitbucket.org/Zagolo/danger-kotlin/pull-requests/1/_/diff#comment-109197958"
+      }
+    },
+    "deleted": false,
+    "pullrequest": {
+      "type": "pullrequest",
+      "id": 1,
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/Zagolo/danger-kotlin/pullrequests/1"
+        },
+        "html": {
+          "href": "https://bitbucket.org/Zagolo/danger-kotlin/pull-requests/1"
+        }
+      },
+      "title": "README.md edited online with Bitbucket"
+    },
+    "content": {
+      "raw": "Test Comment",
+      "markup": "markdown",
+      "html": "<p>Test Comment</p>",
+      "type": "rendered"
+    },
+    "created_on": 1603196142,
+    "user": {
+      "username": "f-meloni",
+      "display_name": "Franco Meloni",
+      "type": "user",
+      "uuid": "{bd1991e4-a3ed-45b2-be38-acea659650f1}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/%7Bbd1991e4-a3ed-45b2-be38-acea659650f1%7D"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%7Bbd1991e4-a3ed-45b2-be38-acea659650f1%7D/"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/3d90e967de2beab6d44cfadbb4976b87?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FFM-1.png"
+        }
+      }
+    },
+    "updated_on": 1603196142,
+    "type": "pullrequest_comment",
+    "id": 109197958
+  }
+"""

--- a/Tests/DangerTests/XCTestManifests.swift
+++ b/Tests/DangerTests/XCTestManifests.swift
@@ -6,6 +6,7 @@
         //   `swift test --generate-linuxmain`
         // to regenerate.
         static let __allTests__BitBucketCloudTests = [
+            ("testCommentUserWithoutAccountId", testCommentUserWithoutAccountId),
             ("testCommitWithoutUser", testCommitWithoutUser),
             ("testParsesActivities", testParsesActivities),
             ("testParsesComments", testParsesComments),


### PR DESCRIPTION
[Issue](https://github.com/danger/swift/issues/360)
Made BitbucketClout.User accountId and nickname optional

