### PR TITLE
Make `force_remove_source_branch` Optional in GitLabDSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Make Danger work well with --package-path [@f-meloni][] - [#406](https://github.com/danger/swift/pull/406)
+- Make `force_remove_source_branch` Optional in GitLabDSL [@417-72KI][] - [#410](https://github.com/danger/swift/pull/410)
 
 ## 3.7.2
 

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -218,7 +218,7 @@ extension GitLab {
         public let diffRefs: DiffRefs
         public let downvotes: Int
         public let firstDeployedToProductionAt: Date?
-        public let forceRemoveSourceBranch: Bool
+        public let forceRemoveSourceBranch: Bool?
         public let id: Int
         public let iid: Int
         public let latestBuildFinishedAt: Date?


### PR DESCRIPTION
fixes #409