### PR TITLE
Test the minimum Swift version supported (5.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: [11.4, 12.3]
+        xcode: [11.2, 11.4, 12.3]
     steps:
     - uses: actions/checkout@v2
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: [5.2.4, 5.3.3]
+        swift: [5.1.1, 5.2.4, 5.3.3]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2


### PR DESCRIPTION
This is expected to fail for Linux because of `swiftenv` cannot build version `5.1.1`.