### PR TITLE
Fix old version support on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Write your Dangerfiles in Swift.
 
 Latest version requires Swift 5.2
 
-- If you are using Swift 5.2 use v3.8.0
+- If you are using Swift 5.1 use v3.8.0
 - If you are using Swift 4.2 use v2.0.7
 - If you are using Swift 4.1 use v0.4.1
 - If you are using Swift 4.0, Use v0.3.6


### PR DESCRIPTION
It seems that v3.8.0 can be used with Swift 5.1