### PR TITLE
Use different structs from GitHub and Git commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Use different structs from GitHub and Git commits [@f-meloni][] - [#433](https://github.com/danger/swift/pull/433)
 - Add support to Danger enviroment [@f-meloni][] - [#431](https://github.com/danger/swift/pull/431)
 
 ## 3.9.1

--- a/Sources/Danger/GitDSL.swift
+++ b/Sources/Danger/GitDSL.swift
@@ -54,7 +54,7 @@ extension Git {
         public let parents: [String]?
 
         /// The URL for the commit.
-        public let url: String
+        public let url: String?
     }
 }
 

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -346,7 +346,7 @@ extension GitHub {
         public let sha: String
 
         /// The raw commit metadata.
-        public let commit: Git.Commit
+        public let commit: CommitData
 
         /// The URL for the commit on GitHub.
         public let url: String
@@ -361,11 +361,34 @@ extension GitHub {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 
             sha = try container.decode(String.self, forKey: .sha)
-            commit = try container.decode(Git.Commit.self, forKey: .commit)
+            commit = try container.decode(CommitData.self, forKey: .commit)
             url = try container.decode(String.self, forKey: .url)
             author = (try? container.decodeIfPresent(User.self, forKey: .author)) ?? nil
             committer = (try? container.decodeIfPresent(User.self, forKey: .committer)) ?? nil
         }
+    }
+}
+
+extension GitHub.Commit {
+    /// A GitHub specific implementation of a github commit.
+    public struct CommitData: Equatable, Decodable {
+        /// The SHA for the commit.
+        public let sha: String?
+
+        /// Who wrote the commit.
+        public let author: Git.Commit.Author
+
+        /// Who shipped the code.
+        public let committer: Git.Commit.Author
+
+        /// The message for the commit.
+        public let message: String
+
+        /// SHAs for the commit's parents.
+        public let parents: [String]?
+
+        /// The URL for the commit.
+        public let url: String
     }
 }
 

--- a/Tests/DangerTests/GitHubTests.swift
+++ b/Tests/DangerTests/GitHubTests.swift
@@ -254,7 +254,7 @@ final class GitHubTests: XCTestCase {
         XCTAssertNil(testCommit.author)
         XCTAssertEqual(testCommit.sha, "cad494648f773cd4fad5a9ea948c1bfabf36032a")
         XCTAssertEqual(testCommit.url, "https://api.github.com/repos/danger/swift/commits/cad494648f773cd4fad5a9ea948c1bfabf36032a")
-        XCTAssertEqual(testCommit.commit, Git.Commit(sha: nil,
+        XCTAssertEqual(testCommit.commit, GitHub.Commit.CommitData(sha: nil,
                                                      author: expectedAuthor,
                                                      committer: expectedAuthor,
                                                      message: "Re use the same executor on the runner",


### PR DESCRIPTION
Using the same struct from both, introduced a bug in 3.9.1

I'm using two different objects, so that the old GitHub public inteface stays the same, and the only change is in the variable that was anyway broken