### PR TITLE
Temporary remove swift 5.4.1 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: [5.2.4, 5.3.3, 5.4.1]
+        swift: [5.2.4, 5.3.3]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: [5.2.4, 5.3.3, 5.4.1]
+        swift: [5.2.4, 5.3.3]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2


### PR DESCRIPTION
Removing until when we bump to swift 5.3, because CryptoSwift 1.0.0 (that is depenency of Swiftlint) doesn't work with swift 5.4.1, but to update it we need to update swift docs, and swift docs requires swift 5.3 to be updated