### PR TITLE
Add Homebrew path for Apple Silicon based macOS installations

### DIFF
--- a/Sources/RunnerLib/Runtime.swift
+++ b/Sources/RunnerLib/Runtime.swift
@@ -20,7 +20,8 @@ public enum Runtime {
         ".build/debug", // Working in Xcode / CLI
         ".build/x86_64-unknown-linux/debug", // Danger Swift's CI
         ".build/release", // Testing prod
-        "/usr/local/lib/danger" // Homebrew installs lib stuff to here
+        "/usr/local/lib/danger", // Intel Homebrew installs lib stuff to here
+        "/opt/homebrew/lib/danger" // Apple Silicon Homebrew installs lib stuff to here
     ]
 
     /// Finds a path to add at runtime to the compiler, which links


### PR DESCRIPTION
The Homebrew install path on Apple Silicon is different from the Intel-based Homebrew setup. This PR adds the new path to `Runtime.swift` to fix the error below.

```
ERROR: Could not find a libDanger to link against at any of: [".build/debug", ".build/x86_64-unknown-linux/debug", ".build/release", "/usr/local/lib/danger"]
```