### PR TITLE
Cache dependencies on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          .build/artifacts
+          .build/checkouts
+          .build/repositories
+        key: ${{ runner.os }}-dependencies-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-dependencies-${{ matrix.xcode }}-
+          ${{ runner.os }}-dependencies-
+          ${{ runner.os }}-
+
     - name: Select Xcode
       run: |
         xcodebuild -version
@@ -44,6 +57,19 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
 
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          .build/artifacts
+          .build/checkouts
+          .build/repositories
+        key: ${{ runner.os }}-dependencies-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-dependencies-${{ matrix.swift }}-
+          ${{ runner.os }}-dependencies-
+          ${{ runner.os }}-
+
     - name: Install danger-js
       run: |
         yarn global add danger
@@ -68,6 +94,19 @@ jobs:
         xcode: ["12.4", "12.5", "13.0"]
     steps:
     - uses: actions/checkout@v2
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          .build/artifacts
+          .build/checkouts
+          .build/repositories
+        key: ${{ runner.os }}-without-spm-package-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-without-spm-package-${{ matrix.xcode }}-
+          ${{ runner.os }}-without-spm-package-
+          ${{ runner.os }}-
 
     - name: Select Xcode
       run: |
@@ -95,6 +134,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          .build/artifacts
+          .build/checkouts
+          .build/repositories
+        key: ${{ runner.os }}-without-spm-package-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-without-spm-package-${{ matrix.swift }}-
+          ${{ runner.os }}-without-spm-package-
+          ${{ runner.os }}-
 
     - name: Install danger-js
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-on-macos-11:
-    name: Test on macOS
+    name: Test on macOS 11
     runs-on: macOS-11
     strategy:
       matrix:
@@ -87,7 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
   test-without-spm-on-macos-11:
-    name: Test without SPM on macOS
+    name: Test without SPM on macOS 11
     runs-on: macOS-11
     strategy:
       matrix:


### PR DESCRIPTION
Sometimes CI fails due to fail fetch dependencies from GitHub.
Caching fetched files may suppress wasting time.

↓ has been duplicated with #414 😅
~~Additionally, `macos-latest` host runner will use `macos-11`.~~
~~So I ~~unify running CI on macOS host to `macos-11`~~ replace `macos-latest` with `macos-10.15`.~~
~~(Installing danger-js with Xcode 11.7 in `macos-11` failed due to Homebrew😅.)~~

<!--![image](https://user-images.githubusercontent.com/4150060/134451692-ba73e3f2-8dff-4b65-aed9-5f49e9b89c0e.png)
![image](https://user-images.githubusercontent.com/4150060/134452079-a80b5728-1c7c-4b7d-b70a-f2594e73805b.png)-->

~~ref: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#installed-sdks~~