### PR TITLE
bump Version package version to >=2.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -294,8 +294,8 @@
         "repositoryURL": "https://github.com/mxcl/Version",
         "state": {
           "branch": null,
-          "revision": "200046c93f6d5d78a6d72bfd9c0b27a95e9c0a2b",
-          "version": "1.2.0"
+          "revision": "1fe824b80d89201652e7eca7c9252269a1d85e25",
+          "version": "2.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/shibapm/Logger", from: "0.1.0"),
-        .package(url: "https://github.com/mxcl/Version", from: "1.0.0"),
+        .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(name: "OctoKit", url: "https://github.com/nerdishbynature/octokit.swift", from: "0.11.0"),
         // Danger Plugins
         // Dev dependencies


### PR DESCRIPTION
[Release 2.0.1 · mxcl/Version](https://github.com/mxcl/Version/releases/tag/2.0.1) was Released. (now using `1.2.0`)

Fortunately, there seems to be no changes of APIs, as I checked on local Xcode Build & Unit Testing.