### PR TITLE
Extract dev dependencies to switch development and release easily

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/Markup.git",
         "state": {
           "branch": null,
-          "revision": "7c6448d3f1af27270f429737ea31ba1517ed472f",
-          "version": "0.1.2"
+          "revision": "c36d9ca11240bae6e3f7f17d29b5cfe3356f97ca",
+          "version": "0.1.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -4,27 +4,42 @@ import PackageDescription
 
 // Version number can be found in Source/Danger/Danger.swift
 
+// switch to false when release
+let isDevelop = true
+
+let devProducts: [Product] = isDevelop
+? [
+    .library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"])
+] : []
+let devDependencies: [Package.Dependency] = isDevelop
+? [
+    .package(url: "https://github.com/shibapm/Komondor", from: "1.0.0"),
+    .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.35.8"),
+    .package(url: "https://github.com/Realm/SwiftLint", from: "0.38.0"),
+    .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.1"),
+    .package(url: "https://github.com/shibapm/Rocket", from: "0.4.0"),
+    .package(url: "https://github.com/SwiftDocOrg/swift-doc", .branch("1.0.0-rc.1")),
+] : []
+let devTargets: [Target] = isDevelop
+? [
+    .testTarget(name: "DangerTests", dependencies: ["Danger", "DangerFixtures", "SnapshotTesting"]),
+    .testTarget(name: "RunnerLibTests", dependencies: ["RunnerLib", "SnapshotTesting"], exclude: ["__Snapshots__"]),
+    .testTarget(name: "DangerDependenciesResolverTests", dependencies: ["DangerDependenciesResolver", "SnapshotTesting"], exclude: ["__Snapshots__"]),
+]
+: []
+
 let package = Package(
     name: "danger-swift",
     products: [
         .library(name: "Danger", targets: ["Danger"]),
         .library(name: "DangerFixtures", targets: ["DangerFixtures"]),
-        .library(name: "DangerDeps", type: .dynamic, targets: ["Danger-Swift"]), // dev
         .executable(name: "danger-swift", targets: ["Runner"]),
-    ],
+    ] + devProducts,
     dependencies: [
         .package(url: "https://github.com/shibapm/Logger", from: "0.1.0"),
         .package(url: "https://github.com/mxcl/Version", from: "1.0.0"),
         .package(name: "OctoKit", url: "https://github.com/nerdishbynature/octokit.swift", from: "0.11.0"),
-        // Danger Plugins
-        // Dev dependencies
-        .package(url: "https://github.com/shibapm/Komondor", from: "1.0.0"), // dev
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.35.8"), // dev
-        .package(url: "https://github.com/Realm/SwiftLint", from: "0.38.0"), // dev
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.1"), // dev
-        .package(url: "https://github.com/shibapm/Rocket", from: "0.4.0"), // dev
-        .package(url: "https://github.com/SwiftDocOrg/swift-doc", .branch("1.0.0-rc.1")), // dev
-    ],
+    ] + devDependencies,
     targets: [
         .target(name: "Danger-Swift", dependencies: ["Danger"]),
         .target(name: "DangerShellExecutor"),
@@ -33,10 +48,7 @@ let package = Package(
         .target(name: "RunnerLib", dependencies: ["Logger", "DangerShellExecutor"]),
         .target(name: "Runner", dependencies: ["RunnerLib", "Logger", "DangerDependenciesResolver"]),
         .target(name: "DangerFixtures", dependencies: ["Danger"]),
-        .testTarget(name: "DangerTests", dependencies: ["Danger", "DangerFixtures", "SnapshotTesting"]),  // dev
-        .testTarget(name: "RunnerLibTests", dependencies: ["RunnerLib", "SnapshotTesting"], exclude: ["__Snapshots__"]), // dev
-        .testTarget(name: "DangerDependenciesResolverTests", dependencies: ["DangerDependenciesResolver", "SnapshotTesting"], exclude: ["__Snapshots__"]),  // dev
-    ]
+    ] + devTargets
 )
 
 #if canImport(PackageConfig)


### PR DESCRIPTION
In this repo, dependencies for development are commented out when release and uncommented soon.
Unfortunately, there has been a fatal issue caused by unhiding Danger Deps (#475).

I think it was a human error, and this PR can avoid it by centralizing management by a simple flag instead of commenting out multiple lines.

When release, we just switch a flag to `false` to make it same condition as previous tags😎