### PR TITLE
Add support for labels on GitHub pull requests

### DIFF
--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -55,6 +55,7 @@ public extension GitHub {
             case htmlUrl = "html_url"
             case draft
             case links = "_links"
+            case labels
         }
 
         public enum PullRequestState: String, Decodable {
@@ -138,6 +139,9 @@ public extension GitHub {
 
         /// Possible link relations
         public let links: Link
+
+        /// The labels associated with this pull request.
+        public let labels: [Label]
     }
 }
 
@@ -418,19 +422,7 @@ public extension GitHub {
             case locked
         }
 
-        public struct Label: Decodable, Equatable {
-            /// The id number of this label.
-            public let id: Int
-
-            /// The URL that links to this label.
-            public let url: String
-
-            /// The name of the label.
-            public let name: String
-
-            /// The color associated with this label.
-            public let color: String
-        }
+        public typealias Label = GitHub.Label
 
         /// The id number of the issue
         public let id: Int
@@ -537,5 +529,21 @@ public extension GitHub {
 
         /// The ISO8601 date string for the due of this milestone.
         public let dueOn: Date?
+    }
+}
+
+public extension GitHub {
+    struct Label: Decodable, Equatable {
+        /// The id number of this label.
+        public let id: Int
+
+        /// The URL that links to this label.
+        public let url: String
+
+        /// The name of the label.
+        public let name: String
+
+        /// The color associated with this label.
+        public let color: String
     }
 }

--- a/Tests/DangerTests/GitHubTests.swift
+++ b/Tests/DangerTests/GitHubTests.swift
@@ -314,6 +314,13 @@ final class GitHubTests: XCTestCase {
             dueOn: Date(timeIntervalSince1970: 1_349_825_941.0)
         )
 
+        let label = GitHub.Label(
+            id: 208045946,
+            url: "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+            name: "bug",
+            color: "f29513"
+        )
+
         let expectedPR = GitHub.PullRequest(
             number: 1347,
             title: "new-feature",
@@ -348,7 +355,8 @@ final class GitHubTests: XCTestCase {
                 reviewComment: "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
                 commits: "https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits",
                 statuses: "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"
-            )
+            ),
+            labels: [label]
         )
 
         XCTAssertEqual(expectedPR, actualPR)


### PR DESCRIPTION
Danger Swift already supported GitHub labels, but only on issues, not pull requests. This PR adds support for those, too.

Please let me know if it’s OK to just drop this PR here or if there’s anything else that needs to be done on my part.