### PR TITLE
Notify a new release on running `danger-swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .target(name: "DangerShellExecutor"),
         .target(name: "DangerDependenciesResolver", dependencies: ["DangerShellExecutor", "Version", "Logger"]),
         .target(name: "Danger", dependencies: ["OctoKit", "Logger", "DangerShellExecutor"]),
-        .target(name: "RunnerLib", dependencies: ["Logger", "DangerShellExecutor"]),
+        .target(name: "RunnerLib", dependencies: ["Logger", "DangerShellExecutor", "Version"]),
         .target(name: "Runner", dependencies: ["RunnerLib", "Logger", "DangerDependenciesResolver"]),
         .target(name: "DangerFixtures", dependencies: ["Danger"]),
     ] + devTargets

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -10,13 +10,18 @@ private func runCommand(_ command: DangerCommand, logger: Logger) throws {
     switch command {
     case .ci, .local, .pr:
         let exitCode = try runDangerJSCommandToRunDangerSwift(command, logger: logger)
-        VersionChecker.checkForUpdate(current: DangerVersion)
+        checkForUpdate(logger: logger)
         exit(exitCode)
     case .edit:
         try editDanger(logger: logger)
     case .runner:
         try runDanger(logger: logger)
     }
+}
+
+private func checkForUpdate(logger: Logger) {
+    let versionChecker = VersionChecker(logger: logger)
+    versionChecker.checkForUpdate(current: DangerVersion)
 }
 
 let cliLength = ProcessInfo.processInfo.arguments.count

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -20,6 +20,9 @@ private func runCommand(_ command: DangerCommand, logger: Logger) throws {
 }
 
 private func checkForUpdate(logger: Logger) {
+    // FIXME: Add another env variable to opt out this check
+    // https://github.com/danger/swift/pull/505#discussion_r799356563
+    guard ProcessInfo.processInfo.environment["DEBUG"] == nil else { return }
     let versionChecker = VersionChecker(logger: logger)
     versionChecker.checkForUpdate(current: DangerVersion)
 }

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -10,6 +10,7 @@ private func runCommand(_ command: DangerCommand, logger: Logger) throws {
     switch command {
     case .ci, .local, .pr:
         let exitCode = try runDangerJSCommandToRunDangerSwift(command, logger: logger)
+        VersionChecker.checkForUpdate(current: DangerVersion)
         exit(exitCode)
     case .edit:
         try editDanger(logger: logger)

--- a/Sources/RunnerLib/VersionChecker.swift
+++ b/Sources/RunnerLib/VersionChecker.swift
@@ -1,0 +1,50 @@
+import DangerShellExecutor
+import Logger
+import Version
+import Foundation
+
+public enum VersionChecker {
+    public static func checkForUpdate(current currentVersionString: String) {
+        if ProcessInfo.processInfo.environment["DEBUG"] != nil {
+            return
+        }
+        guard let latestVersionString = fetchLatestVersion() else { return }
+        guard let latestVersion = Version(latestVersionString) else {
+            logger.debug("Invalid latestVersionString: (\(latestVersionString)")
+            return
+        }
+        guard let currentVersion = Version(currentVersionString) else {
+            logger.debug("Invalid currentVersionString: (\(currentVersionString)")
+            return
+        }
+        if currentVersion < latestVersion {
+            logger.logInfo("\nℹ️  A new release of danger-swift is available: \(currentVersion) -> \(latestVersion)")
+        }
+    }
+
+    static func fetchLatestVersion() -> String? {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            let latest = try ShellExecutor().execute("curl",
+                                                     arguments: [
+                                                        "-s",
+                                                        "https://api.github.com/repos/danger/swift/releases/latest"
+                                                     ])
+                .data(using: .utf8)
+                .flatMap { try decoder.decode(Release.self, from: $0) }
+            return latest?.tagName
+        } catch {
+            logger.debug(error)
+            return nil
+        }
+    }
+}
+
+extension VersionChecker {
+    static let logger = Logger()
+}
+
+struct Release: Codable {
+    var tagName: String
+}

--- a/Sources/RunnerLib/VersionChecker.swift
+++ b/Sources/RunnerLib/VersionChecker.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public enum VersionChecker {
     public static func checkForUpdate(current currentVersionString: String) {
-        if ProcessInfo.processInfo.environment["DEBUG"] != nil {
+        guard ProcessInfo.processInfo.environment["DEBUG"] == nil else {
             return
         }
         guard let latestVersionString = fetchLatestVersion() else { return }

--- a/Sources/RunnerLib/VersionChecker.swift
+++ b/Sources/RunnerLib/VersionChecker.swift
@@ -4,11 +4,11 @@ import Version
 import Foundation
 
 public struct VersionChecker {
-    private let shellExecutor: ShellExecutor
+    private let shellExecutor: ShellExecuting
     private let logger: Logger
 
     public init(
-        shellExecutor: ShellExecutor = .init(),
+        shellExecutor: ShellExecuting = ShellExecutor(),
         logger: Logger
     ) {
         self.shellExecutor = shellExecutor

--- a/Sources/RunnerLib/VersionChecker.swift
+++ b/Sources/RunnerLib/VersionChecker.swift
@@ -18,9 +18,6 @@ public class VersionChecker {
 
 public extension VersionChecker {
     func checkForUpdate(current currentVersionString: String) {
-        guard ProcessInfo.processInfo.environment["DEBUG"] == nil else {
-            return
-        }
         guard let latestVersionString = fetchLatestVersion() else { return }
         guard let latestVersion = Version(latestVersionString) else {
             logger.debug("Invalid latestVersionString: (\(latestVersionString)")

--- a/Sources/RunnerLib/VersionChecker.swift
+++ b/Sources/RunnerLib/VersionChecker.swift
@@ -3,7 +3,7 @@ import Logger
 import Version
 import Foundation
 
-public class VersionChecker {
+public struct VersionChecker {
     private let shellExecutor: ShellExecutor
     private let logger: Logger
 

--- a/Tests/RunnerLibTests/VersionCheckerTests.swift
+++ b/Tests/RunnerLibTests/VersionCheckerTests.swift
@@ -1,0 +1,57 @@
+//
+//  VersionCheckerTests.swift
+//  
+//
+//  Created by 417.72KI on 2022/02/20.
+//
+
+import Logger
+@testable import RunnerLib
+import XCTest
+
+final class VersionCheckerTests: XCTestCase {
+
+    private var executor: MockedExecutor!
+    private var spyPrinter: SpyPrinter!
+
+    override func setUp() {
+        executor = MockedExecutor()
+        spyPrinter = SpyPrinter()
+    }
+
+    func testItShowsNotificationIfNewVersionIsAvailable() throws {
+        executor.result = mockResult(tagName: "1.0.1")
+
+        let versionChecker = VersionChecker(
+            shellExecutor: executor,
+            logger: Logger(
+                isVerbose: false,
+                isSilent: false,
+                printer: spyPrinter
+            )
+        )
+        versionChecker.checkForUpdate(current: "1.0.0")
+        XCTAssertTrue(spyPrinter.printedMessages.contains { $0.contains("A new release of danger-swift is available") })
+    }
+
+    func testItNotShowNotificationIfRunningIsLatest() throws {
+        executor.result = mockResult(tagName: "1.0.0")
+
+        let versionChecker = VersionChecker(
+            shellExecutor: executor,
+            logger: Logger(
+                isVerbose: false,
+                isSilent: false,
+                printer: spyPrinter
+            )
+        )
+        versionChecker.checkForUpdate(current: "1.0.0")
+        XCTAssertFalse(spyPrinter.printedMessages.contains { $0.contains("A new release of danger-swift is available") })
+    }
+}
+
+private extension VersionCheckerTests {
+    func mockResult(tagName: String) -> (String) -> String {
+       { _ in #"{"tagName": "\#(tagName)"}"# }
+    }
+}


### PR DESCRIPTION
Some tools (e.g. `carthage`, `gh`, etc...) notify when new version is released.
I added a version checker to fetch a latest release in GitHub, and notify if running version is older than latest.