### PR TITLE
Bump dependencies to avoid SwiftLint build-error in Swift 5.5.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,66 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Commandant",
-        "repositoryURL": "https://github.com/Carthage/Commandant.git",
-        "state": {
-          "branch": null,
-          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
-          "version": "0.17.0"
-        }
-      },
-      {
-        "package": "CommonMark",
-        "repositoryURL": "https://github.com/SwiftDocOrg/CommonMark.git",
-        "state": {
-          "branch": null,
-          "revision": "92fa2fa2bf3c598f23da652e78c2d4b5bc4e35e9",
-          "version": "0.5.1"
-        }
-      },
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "GraphViz",
-        "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
-        "state": {
-          "branch": null,
-          "revision": "74b6cbd8c5ecea9f64d84c4e1c88d65604dd033f",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "HypertextLiteral",
-        "repositoryURL": "https://github.com/NSHipster/HypertextLiteral.git",
-        "state": {
-          "branch": null,
-          "revision": "3993d13c1e1d72a2ab20316646b2d53a705b17d0",
-          "version": "0.0.3"
-        }
-      },
-      {
         "package": "Komondor",
         "repositoryURL": "https://github.com/shibapm/Komondor",
         "state": {
           "branch": null,
-          "revision": "1bb467ad7ad57e94af82d73fa0fe063cb0b8ddd5",
-          "version": "1.1.0"
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
         }
       },
       {
@@ -71,24 +17,6 @@
           "branch": null,
           "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
           "version": "0.2.3"
-        }
-      },
-      {
-        "package": "Markup",
-        "repositoryURL": "https://github.com/SwiftDocOrg/Markup.git",
-        "state": {
-          "branch": null,
-          "revision": "c36d9ca11240bae6e3f7f17d29b5cfe3356f97ca",
-          "version": "0.1.3"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
-          "version": "8.1.2"
         }
       },
       {
@@ -105,17 +33,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
-          "version": "0.13.0"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
-          "version": "2.2.1"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -132,8 +51,8 @@
         "repositoryURL": "https://github.com/shibapm/Rocket",
         "state": {
           "branch": null,
-          "revision": "f75c9736733b489a3456b4f3a47cf13adb99f197",
-          "version": "0.9.2"
+          "revision": "9880a5beb7fcb9e61ddd5764edc1700b8c418deb",
+          "version": "1.2.1"
         }
       },
       {
@@ -150,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "97b5848e5692150d75b5cf0b81d7ebef5f4d5071",
-          "version": "0.28.0"
+          "revision": "558628392eb31d37cb251cfe626c53eafd330df6",
+          "version": "0.31.1"
         }
       },
       {
@@ -159,44 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
-        }
-      },
-      {
-        "package": "cmark",
-        "repositoryURL": "https://github.com/SwiftDocOrg/swift-cmark.git",
-        "state": {
-          "branch": null,
-          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
-          "version": "0.29.0+20210102.9c8096a"
-        }
-      },
-      {
-        "package": "swift-doc",
-        "repositoryURL": "https://github.com/SwiftDocOrg/swift-doc",
-        "state": {
-          "branch": "1.0.0-rc.1",
-          "revision": "f935ebfe524a0ff27bda07dadc3662e3e45b5125",
-          "version": null
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "LoggingGitHubActions",
-        "repositoryURL": "https://github.com/NSHipster/swift-log-github-actions.git",
-        "state": {
-          "branch": null,
-          "revision": "13ce1e95e5b0c5fffa7667214d42e1f316693ef5",
-          "version": "0.0.1"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {
@@ -209,21 +92,12 @@
         }
       },
       {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
-        "state": {
-          "branch": "0.50300.0",
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": null
-        }
-      },
-      {
         "package": "SwiftFormat",
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "fab94f3ca17f0f75e87787ed83b3a9423348b14c",
-          "version": "0.49.1"
+          "revision": "f14f4f717e7e1d275acd7557d64c94cfef5723e6",
+          "version": "0.49.4"
         }
       },
       {
@@ -231,26 +105,8 @@
         "repositoryURL": "https://github.com/Realm/SwiftLint",
         "state": {
           "branch": null,
-          "revision": "da66a81710714112d51041264440987b992849c3",
-          "version": "0.40.0"
-        }
-      },
-      {
-        "package": "SwiftMarkup",
-        "repositoryURL": "https://github.com/SwiftDocOrg/SwiftMarkup.git",
-        "state": {
-          "branch": null,
-          "revision": "bc71bde93b5217833c8ed13d5cf1e0c60f1367a7",
-          "version": "0.3.0"
-        }
-      },
-      {
-        "package": "SwiftSemantics",
-        "repositoryURL": "https://github.com/SwiftDocOrg/SwiftSemantics.git",
-        "state": {
-          "branch": null,
-          "revision": "7690606eec5db6b089d6a5d252013ee07cade323",
-          "version": "0.3.2"
+          "revision": "b4a54f32df66008d30f0229446831cb823576c42",
+          "version": "0.46.2"
         }
       },
       {
@@ -258,17 +114,8 @@
         "repositoryURL": "https://github.com/kareman/SwiftShell",
         "state": {
           "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
-        }
-      },
-      {
-        "package": "SwiftSyntaxHighlighter",
-        "repositoryURL": "https://github.com/NSHipster/SwiftSyntaxHighlighter.git",
-        "state": {
-          "branch": "1.2.2",
-          "revision": "175923d005df00dc76c3c191bd7977c066a5288c",
-          "version": null
+          "revision": "a6014fe94c3dbff0ad500e8da4f251a5d336530b",
+          "version": "5.1.0-beta.1"
         }
       },
       {
@@ -303,8 +150,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let devDependencies: [Package.Dependency] = isDevelop
         .package(url: "https://github.com/Realm/SwiftLint", from: "0.46.2"),
         .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.1"),
         .package(url: "https://github.com/shibapm/Rocket", from: "1.2.1"),
-        // .package(url: "https://github.com/SwiftDocOrg/swift-doc", .branch("1.0.0-rc.1")),
     ] : []
 let devTargets: [Target] = isDevelop
     ? [
@@ -73,7 +72,6 @@ let package = Package(
                 "Scripts/update_makefile.sh",
                 "Scripts/update_danger_version.sh",
                 "Scripts/update_changelog.sh",
-                // "make docs",
             ],
             "after": [
                 "Scripts/create_homebrew_tap.sh",

--- a/Package.swift
+++ b/Package.swift
@@ -13,12 +13,12 @@ let devProducts: [Product] = isDevelop
     ] : []
 let devDependencies: [Package.Dependency] = isDevelop
     ? [
-        .package(url: "https://github.com/shibapm/Komondor", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.35.8"),
-        .package(url: "https://github.com/Realm/SwiftLint", from: "0.38.0"),
+        .package(url: "https://github.com/shibapm/Komondor", from: "1.1.3"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.49.4"),
+        .package(url: "https://github.com/Realm/SwiftLint", from: "0.46.2"),
         .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.1"),
-        .package(url: "https://github.com/shibapm/Rocket", from: "0.4.0"),
-        .package(url: "https://github.com/SwiftDocOrg/swift-doc", .branch("1.0.0-rc.1")),
+        .package(url: "https://github.com/shibapm/Rocket", from: "1.2.1"),
+        // .package(url: "https://github.com/SwiftDocOrg/swift-doc", .branch("1.0.0-rc.1")),
     ] : []
 let devTargets: [Target] = isDevelop
     ? [
@@ -73,7 +73,7 @@ let package = Package(
                 "Scripts/update_makefile.sh",
                 "Scripts/update_danger_version.sh",
                 "Scripts/update_changelog.sh",
-                "make docs",
+                // "make docs",
             ],
             "after": [
                 "Scripts/create_homebrew_tap.sh",


### PR DESCRIPTION
There is some problem that SwiftLint build fails on Swift 5.5.2.
https://github.com/danger/swift/runs/5258863489?check_suite_focus=true#step:10:69

I tried to bump it and found version conflicts on some dependencies, so I make them all to latest.

Additionally, [swift-doc](https://github.com/SwiftDocOrg/swift-doc)is archived and not maintained any more, which causes version conflict too.
It seems to be necessary to run `make docs`, so I comment-out temporary instead of removing.