### PR TITLE
bump Xcode requirement in Homebrew to 12

### DIFF
--- a/Scripts/create_homebrew_tap.sh
+++ b/Scripts/create_homebrew_tap.sh
@@ -30,8 +30,8 @@ echo "  url \"https://github.com/danger/danger-swift/archive/#{version}.tar.gz\"
 echo "  sha256 \"${SHA}\"" >> danger-swift.rb
 echo "  head \"https://github.com/danger/danger-swift.git\""  >> danger-swift.rb
 echo >> danger-swift.rb
-echo "  # Runs only on Xcode 10" >> danger-swift.rb
-echo "  depends_on :xcode => [\"10\", :build]" >> danger-swift.rb
+echo "  # Runs only on Xcode 12" >> danger-swift.rb
+echo "  depends_on :xcode => [\"12\", :build]" >> danger-swift.rb
 echo "  # Use the vendored danger" >> danger-swift.rb
 echo "  depends_on \"danger/tap/danger-js\"" >> danger-swift.rb
 echo >> danger-swift.rb


### PR DESCRIPTION
Since latest version of Danger-Swift requires Swift 5.3, it should also require Xcode 12.0

ref: https://developer.apple.com/jp/support/xcode/