### PR TITLE
Add platform requirements on `danger-swift edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 
 ## Master
 
+- Add platform requirements on `danger-swift edit` [@417-72KI][] - [#518](https://github.com/danger/swift/pull/518)
 - Notify a new release on running danger-swift [@417-72KI][] - [#505](https://github.com/danger/swift/pull/505)
-- Remove `swift-doc` from dependencies treee [@417-72KI][] - [#509](https://github.com/danger/swift/pull/509)
+- Remove `swift-doc` from dependencies tree [@417-72KI][] - [#509](https://github.com/danger/swift/pull/509)
 - Generate docker image with swift 5.5.2 [@f-meloni][] - [#501](https://github.com/danger/swift/pull/501)
 - Extract dev dependencies to switch development and release easily [@417-72KI][] - [#491](https://github.com/danger/swift/pull/491)
 

--- a/Sources/DangerDependenciesResolver/PackageGenerator.swift
+++ b/Sources/DangerDependenciesResolver/PackageGenerator.swift
@@ -23,14 +23,17 @@ struct PackageGenerator {
         }
     }
 
-    func generateMasterPackageDescription(forSwiftToolsVersion toolsVersion: Version) throws {
+    func generateMasterPackageDescription(forSwiftToolsVersion toolsVersion: Version,
+                                          macOSVersion: Version) throws {
         let header = makePackageDescriptionHeader(forSwiftToolsVersion: toolsVersion)
         let packages = packageListMaker.makePackageList()
+        let platform = makeSupportedPlatform(forMacOSVersion: macOSVersion)
 
         var description = "\(header)\n\n" +
             "import PackageDescription\n\n" +
             "let package = Package(\n" +
             "    name: \"\(masterPackageName)\",\n" +
+            (platform.isEmpty ? "" : "    platforms: [\(platform)],\n") +
             "    products: [.library(name: \"DangerDependencies\", " +
             "type: .dynamic, targets: [\"\(masterPackageName)\"])]," +
             "\n" +
@@ -73,5 +76,17 @@ struct PackageGenerator {
 
         return "// swift-tools-version:\(swiftVersion)\n" +
             "// danger-dependency-generator-version:\(generationVersion)"
+    }
+
+    func makeSupportedPlatform(forMacOSVersion macOSVersion: Version) -> String {
+        if case .null = macOSVersion { return "" }
+        switch macOSVersion.major {
+        case 10 where (10...15).contains(macOSVersion.minor):
+            return ".macOS(.v10_\(macOSVersion.minor))"
+        case 11...:
+            return ".macOS(.v\(macOSVersion.major))"
+        default:
+            return ""
+        }
     }
 }

--- a/Sources/DangerDependenciesResolver/PackageGenerator.swift
+++ b/Sources/DangerDependenciesResolver/PackageGenerator.swift
@@ -72,7 +72,7 @@ struct PackageGenerator {
 
     func makePackageDescriptionHeader(forSwiftToolsVersion toolsVersion: Version) -> String {
         let swiftVersion = "\(toolsVersion.major).\(toolsVersion.minor)"
-        let generationVersion = 1
+        let generationVersion = 2
 
         return "// swift-tools-version:\(swiftVersion)\n" +
             "// danger-dependency-generator-version:\(generationVersion)"

--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -189,7 +189,14 @@ public struct PackageManager {
         var versionString = executor.execute("sw_vers",
                                              arguments: ["-productVersion"])
         versionString = versionString.onlyNumbersAndDots ?? versionString
-        
+        switch versionString.components(separatedBy: ".").count {
+        case 1:
+            versionString += ".0.0"
+        case 2:
+            versionString += ".0"
+        default:
+            break
+        }
         return Version(versionString) ?? .null
         #else
         return .null

--- a/Sources/DangerDependenciesResolver/PackageManager.swift
+++ b/Sources/DangerDependenciesResolver/PackageManager.swift
@@ -143,8 +143,11 @@ public struct PackageManager {
         let toolsVersion = try resolveSwiftToolsVersion(executor: ShellExecutor(), onFolder: generatedFolder)
         let expectedHeader = packageGenerator.makePackageDescriptionHeader(forSwiftToolsVersion: toolsVersion)
 
+        let macOSVersion = resolveMacOSVersion(executor: ShellExecutor())
+
         guard masterDescription.hasPrefix(expectedHeader) else {
-            try packageGenerator.generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion)
+            try packageGenerator.generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion,
+                                                                  macOSVersion: macOSVersion)
             return try makePackageDescription(for: script)
         }
 
@@ -160,10 +163,11 @@ public struct PackageManager {
             let executor = ShellExecutor()
 
             let toolsVersion = try resolveSwiftToolsVersion(executor: executor, onFolder: generatedFolder)
+            let macOSVersion = resolveMacOSVersion(executor: executor)
             try generatedFolder.createSubfolderIfNeeded(withName: "Sources/\(masterPackageName)")
             fileCreator.createFile(atPath: generatedFolder.appendingPath("Sources/\(masterPackageName)").appendingPath(fakeFile),
                                    contents: Data())
-            try packageGenerator.generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion)
+            try packageGenerator.generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion, macOSVersion: macOSVersion)
             try executeSwiftCommand("package update", onFolder: generatedFolder, arguments: [], executor: executor)
             try generatedFolder.createSubfolderIfNeeded(withName: "Packages")
         } catch {
@@ -178,6 +182,18 @@ public struct PackageManager {
                                                              executor: executor)
         versionString = versionString?.onlyNumbersAndDots
         return Version(versionString ?? "") ?? .null
+    }
+
+    private func resolveMacOSVersion(executor: ShellExecutor) -> Version {
+        #if os(macOS)
+        var versionString = executor.execute("sw_vers",
+                                             arguments: ["-productVersion"])
+        versionString = versionString.onlyNumbersAndDots ?? versionString
+        
+        return Version(versionString) ?? .null
+        #else
+        return .null
+        #endif
     }
 }
 

--- a/Tests/DangerDependenciesResolverTests/PackageGeneratorTests.swift
+++ b/Tests/DangerDependenciesResolverTests/PackageGeneratorTests.swift
@@ -17,7 +17,7 @@ final class PackageGeneratorTests: XCTestCase {
                                          packageListMaker: packageListMaker,
                                          fileCreator: spyFileCreator)
 
-        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 0, 0))
+        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 0, 0), macOSVersion: .init(12, 0, 0))
 
         assertSnapshot(matching: String(data: spyFileCreator.receivedContents!, encoding: .utf8)!, as: .lines)
     }
@@ -34,7 +34,7 @@ final class PackageGeneratorTests: XCTestCase {
                                          packageListMaker: packageListMaker,
                                          fileCreator: spyFileCreator)
 
-        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 0, 0))
+        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 0, 0), macOSVersion: .init(12, 0, 0))
 
         assertSnapshot(matching: String(data: spyFileCreator.receivedContents!, encoding: .utf8)!, as: .lines)
     }
@@ -51,7 +51,7 @@ final class PackageGeneratorTests: XCTestCase {
                                          packageListMaker: packageListMaker,
                                          fileCreator: spyFileCreator)
 
-        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 2, 0))
+        try generator.generateMasterPackageDescription(forSwiftToolsVersion: .init(5, 2, 0), macOSVersion: .init(12, 0, 0))
 
         assertSnapshot(matching: String(data: spyFileCreator.receivedContents!, encoding: .utf8)!, as: .lines)
     }

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedDescriptionHeader.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedDescriptionHeader.1.txt
@@ -1,2 +1,2 @@
 // swift-tools-version:4.2
-// danger-dependency-generator-version:1
+// danger-dependency-generator-version:2

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependencies.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependencies.1.txt
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "PACKAGES",
+    platforms: [.macOS(.v12)],
     products: [.library(name: "DangerDependencies", type: .dynamic, targets: ["PACKAGES"])],
     dependencies: [
         .package(url: "https://github.com/danger/dependency1", from: "1.0.0"),

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependencies.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependencies.1.txt
@@ -1,5 +1,5 @@
 // swift-tools-version:5.0
-// danger-dependency-generator-version:1
+// danger-dependency-generator-version:2
 
 import PackageDescription
 

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "PACKAGES",
+    platforms: [.macOS(.v12)],
     products: [.library(name: "DangerDependencies", type: .dynamic, targets: ["PACKAGES"])],
     dependencies: [
         .package(name: "Dependency1", url: "https://github.com/danger/dependency1", from: "1.0.0"),

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreDependenciesAndSwiftVersionIs5_2.1.txt
@@ -1,5 +1,5 @@
 // swift-tools-version:5.2
-// danger-dependency-generator-version:1
+// danger-dependency-generator-version:2
 
 import PackageDescription
 

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreNoDependencies.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreNoDependencies.1.txt
@@ -1,5 +1,5 @@
 // swift-tools-version:5.0
-// danger-dependency-generator-version:1
+// danger-dependency-generator-version:2
 
 import PackageDescription
 

--- a/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreNoDependencies.1.txt
+++ b/Tests/DangerDependenciesResolverTests/__Snapshots__/PackageGeneratorTests/testGeneratedPackageWhenThereAreNoDependencies.1.txt
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "PACKAGES",
+    platforms: [.macOS(.v12)],
     products: [.library(name: "DangerDependencies", type: .dynamic, targets: ["PACKAGES"])],
     dependencies: [
 


### PR DESCRIPTION
When running `danger-swift edit`, Package.swift does not specify macOS version and generated xcodeproj's deployment target will be 10.10.

This PR makes it possible to set Deployment Target based on running machine.

![image](https://user-images.githubusercontent.com/4150060/169247765-6bbfb597-29d3-42d2-a259-65e959c580d6.png)

I don't know why, but it resolves weirdly errors on `import Danger` (e.g. https://github.com/danger/swift/issues/464#issuecomment-997418557)