### PR TITLE
Patch-fix for `error: incompatible target arm64-apple-macosx10.10` on M1 mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Run danger-swift with x86_64 arch on M1 mac (patch-fix for [#464](https://github.com/danger/swift/issues/464)) [@417-72KI][] - [#521](https://github.com/danger/swift/pull/521)
 - Add platform requirements on `danger-swift edit` [@417-72KI][] - [#518](https://github.com/danger/swift/pull/518)
 - Notify a new release on running danger-swift [@417-72KI][] - [#505](https://github.com/danger/swift/pull/505)
 - Remove `swift-doc` from dependencies tree [@417-72KI][] - [#509](https://github.com/danger/swift/pull/509)

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -36,7 +36,7 @@ if [[ "$?" -eq 0 || "$OSTYPE" == "darwin"* ]]
 then
     BUILD_FOLDER=".build/release"
     if [[ `uname -m` == 'arm64' ]]; then
-        swift build --disable-sandbox --arch arm64 -c release
+        swift build --disable-sandbox --arch x86_64 -c release
     else
         swift build --disable-sandbox -c release
     fi

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -36,6 +36,7 @@ if [[ "$?" -eq 0 || "$OSTYPE" == "darwin"* ]]
 then
     BUILD_FOLDER=".build/release"
     if [[ `uname -m` == 'arm64' ]]; then
+        # FIXME: patch to fix `error: module 'Danger' was created for incompatible target arm64-apple-macosx10.10: /opt/homebrew/lib/danger/Danger.swiftmodule`
         swift build --disable-sandbox --arch x86_64 -c release
     else
         swift build --disable-sandbox -c release


### PR DESCRIPTION
Fixes: #464 

Note: This is not a fundamental solution, and should be reverted when compiler's bug fixes.