### PR TITLE
Suffix temporary directory with unique path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Drop Swift 5.3 support [@417-72KI][] - [#524](https://github.com/danger/swift/pull/524)
+- Refine runner temporary path to better support concurrent pipelines [@squarefrog][] - [#530](https://github.com/danger/swift/pull/530)
 
 ## 3.13.0
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -9,8 +9,13 @@ func runDanger(logger: Logger) throws {
     // Pull in the JSON from Danger JS
     let standardInput = FileHandle.standardInput
     let fileManager = FileManager.default
-    let tmpPath = NSTemporaryDirectory()
+    let tmpPath = NSTemporaryDirectory() + "danger/\(UUID().uuidString)/"
     let dangerResponsePath = tmpPath + "danger-response.json"
+
+    try fileManager.createDirectory(
+        at: URL(fileURLWithPath: tmpPath),
+        withIntermediateDirectories: true
+    )
 
     // Pull in the JSON from Danger JS
     guard let dangerDSLURL = String(data: standardInput.readDataToEndOfFile(), encoding: .utf8) else {

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -187,7 +187,7 @@ func runDanger(logger: Logger) throws {
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)
-    try? fileManager.removeItem(atPath: tmpPath)
+    try? fileManager.removeItem(atPath: tempDangerfilePath)
 
     // Return the same error code as the compilation
     exit(proc.terminationStatus)

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -177,8 +177,7 @@ func runDanger(logger: Logger) throws {
         logger.logError("Could not get the results JSON file at \(dangerResponsePath)")
         // Clean up after ourselves
         try? fileManager.removeItem(atPath: dslJSONPath)
-        try? fileManager.removeItem(atPath: tempDangerfilePath)
-        try? fileManager.removeItem(atPath: dangerResponsePath)
+        try? fileManager.removeItem(atPath: tmpPath)
         exit(1)
     }
 
@@ -188,7 +187,7 @@ func runDanger(logger: Logger) throws {
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)
-    try? fileManager.removeItem(atPath: tempDangerfilePath)
+    try? fileManager.removeItem(atPath: tmpPath)
 
     // Return the same error code as the compilation
     exit(proc.terminationStatus)


### PR DESCRIPTION
Fixes #529

Reusing the temporary directory can cause issues with concurrent instances of Danger. By appending a unique identifier we can prevent race conditions when running Danger from concurrent processes.