### PR TITLE
Add reviewers property to GitLabDSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add `reviewers` property for GitLab merge requests [@pouyayarandi][] - [#534](https://github.com/danger/swift/pull/534)
+
 ## 3.14.0
 
 - Drop Swift 5.3 support [@417-72KI][] - [#524](https://github.com/danger/swift/pull/524)
@@ -527,3 +529,4 @@ This release also includes:
 [@vc7]: https://github.com/vc7
 [@lunij]: https://github.com/lunij
 [@majd]: https://github.com/majd
+[@pouyayarandi]: https://github.com/pouyayarandi

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -188,6 +188,7 @@ public extension GitLab {
             case milestone
             case pipeline
             case projectId = "project_id"
+            case reviewers
             case sha
             case shouldRemoveSourceBranch = "should_remove_source_branch"
             case sourceBranch = "source_branch"
@@ -231,6 +232,7 @@ public extension GitLab {
         public let milestone: Milestone?
         public let pipeline: Pipeline?
         public let projectId: Int
+        public let reviewers: [User]?
         public let sha: String
         public let shouldRemoveSourceBranch: Bool?
         public let sourceBranch: String

--- a/Sources/DangerFixtures/DangerDSLResources/DangerDSLGitLab.swift
+++ b/Sources/DangerFixtures/DangerDSLResources/DangerDSLGitLab.swift
@@ -83,6 +83,16 @@ public let DSLGitLabJSON = """
             "web_url": "https://gitlab.com/orta"
           }
         ],
+        "reviewers": [
+          {
+            "id": 377669,
+            "name": "Orta",
+            "username": "orta",
+            "state": "active",
+            "avatar_url": "https://secure.gravatar.com/avatar/f116cb3be23153ec08b94e8bd4dbcfeb?s=80&d=identicon",
+            "web_url": "https://gitlab.com/orta"
+          }
+        ],
         "source_project_id": 10132593,
         "target_project_id": 1620437,
         "labels": [],

--- a/Tests/DangerTests/GitLabTests.swift
+++ b/Tests/DangerTests/GitLabTests.swift
@@ -73,6 +73,7 @@ final class GitLabTests: XCTestCase {
         XCTAssertEqual(mergeRequest.milestone, expectedMilestone)
         XCTAssertEqual(mergeRequest.pipeline, expectedPipeline)
         XCTAssertEqual(mergeRequest.projectId, 1_620_437)
+        XCTAssertEqual(mergeRequest.reviewers?.first, orta)
         XCTAssertEqual(mergeRequest.sha, "621bc3348549e51c5bd6ea9f094913e9e4667c7b")
         XCTAssertNil(mergeRequest.shouldRemoveSourceBranch)
         XCTAssertEqual(mergeRequest.sourceBranch, "patch-2")


### PR DESCRIPTION
This PR adds `reviewers` property to gitlab merge requests. This property is an array of `User`s who are responsible for reviewing a merge request.