### PR TITLE
feat: Update SwiftLint used by danger-swift-with-swiftlint to 0.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Add `reviewers` property for GitLab merge requests [@pouyayarandi][] - [#534](https://github.com/danger/swift/pull/534)
+- Update [SwiftLint][] used by [danger-swift-with-swiftlint][] from v0.46.1 to [v0.49.1](https://github.com/realm/SwiftLint/releases/tag/0.49.1). [@Kiran-B][] - [#538](https://github.com/danger/swift/pull/538)
 
 ## 3.14.0
 
@@ -530,3 +531,6 @@ This release also includes:
 [@lunij]: https://github.com/lunij
 [@majd]: https://github.com/majd
 [@pouyayarandi]: https://github.com/pouyayarandi
+[@Kiran-B]: https://github.com/Kiran-B
+[SwiftLint]: https://github.com/realm/SwiftLint
+[danger-swift-with-swiftlint]: https://github.com/orgs/danger/packages/container/package/danger-swift-with-swiftlint

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -q \
     && rm -r /var/lib/apt/lists/*
 
 
-# RUN git clone -b 0.46.1 --single-branch --depth 1 https://github.com/realm/SwiftLint.git _swiftlint && cd _swiftlint && git submodule update --init --recursive && make install && rm -rf _swiftlint # swiftlint
+# RUN git clone -b 0.49.1 --single-branch --depth 1 https://github.com/realm/SwiftLint.git _swiftlint && cd _swiftlint && git submodule update --init --recursive && make install && rm -rf _swiftlint # swiftlint
 
 # Install danger-swift globally
 COPY . _danger-swift


### PR DESCRIPTION
Update `SwiftLint` from v0.46.1 -> 0.49.1 in the Dockerfile.

Details about whats new in SwiftLint is available here: 
https://github.com/realm/SwiftLint/releases