### PR TITLE
Bump swift docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.5.3-focal
+FROM swift:5.7.0-focal
 
 MAINTAINER Orta Therox
 


### PR DESCRIPTION
We got some weird issue because of incompatible `Package.resolved` files. Mostly because or toolchain is on swift 5.7 and the docker image we use in the GitHub actions is on 5.3.3.

Not sure what the procedure is around here with bumping to the latest swift build tools. So feel free to close if this is too early or I should create an issue first.