### PR TITLE
Resolve `// fileImport: ~` path to an absolute path on running `danger-swift edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Gitlab Error in merge request with estimate or spent time [@oscarcv][] - [#548](https://github.com/danger/swift/pull/548)
+- Resolve `// fileImport: ~` path to an absolute path on running `danger-swift edit` [@417-72KI][] - [#565](https://github.com/danger/swift/pull/565)
 
 ## 3.15.0
 

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -8,9 +8,9 @@ func editDanger(logger: Logger) throws {
     let dangerfilePath: String
 
     if let dangerfileArgumentPath = DangerfilePathFinder.dangerfilePath() {
-        dangerfilePath = dangerfileArgumentPath
+        dangerfilePath = dangerfileArgumentPath.fullPath
     } else {
-        dangerfilePath = Runtime.getDangerfile() ?? "Dangerfile.swift"
+        dangerfilePath = (Runtime.getDangerfile() ?? "Dangerfile.swift").fullPath
     }
 
     if !fileManager.fileExists(atPath: dangerfilePath) {

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -44,6 +44,7 @@ func editDanger(logger: Logger) throws {
 
     let importsFinder = ImportsFinder()
     let importedFiles = importsFinder.findImports(inString: dangerfileContent)
+        .map { importsFinder.resolveImportPath($0, relativeTo: dangerfilePath) }
 
     let scriptManager = try getScriptManager(logger)
     let script = try scriptManager.script(atPath: dangerfilePath)

--- a/Sources/RunnerLib/Files Import/ImportsFinder.swift
+++ b/Sources/RunnerLib/Files Import/ImportsFinder.swift
@@ -10,4 +10,11 @@ public final class ImportsFinder {
 
         return files
     }
+
+    public func resolveImportPath(_ path: String,
+                                  relativeTo dangerfilePath: String) -> String {
+        dangerfilePath
+            .removingLastPathComponent()
+            .appendingPath(path)
+    }
 }

--- a/Tests/RunnerLibTests/ImportsFinderTests.swift
+++ b/Tests/RunnerLibTests/ImportsFinderTests.swift
@@ -21,6 +21,13 @@ final class ImportsFinderTests: XCTestCase {
     func testItRetunsAnEmptyListWhenThePassedStringDoesntContainImports() {
         checkReturnsTheCorrectFilePaths(string: stringWithoutImports, expectedResult: [])
     }
+
+    func testResolveImportPath() {
+        let dangerfilePath = "/path/to/danger/swift/Dangerfile.swift"
+        XCTAssertEqual(importsFinder.resolveImportPath("DangerfileExtensions/ChangelogCheck.swift", relativeTo: dangerfilePath), "/path/to/danger/swift/DangerfileExtensions/ChangelogCheck.swift")
+
+        XCTAssertEqual(importsFinder.resolveImportPath("SomeFile", relativeTo: dangerfilePath), "/path/to/danger/swift/SomeFile")
+    }
 }
 
 extension ImportsFinderTests {


### PR DESCRIPTION
Resolves: #564 