### PR TITLE
Add ability to change meta information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Gitlab Error in merge request with estimate or spent time [@oscarcv][] - [#548](https://github.com/danger/swift/pull/548)
+- Add ability to change meta information [@Nikoloutsos][] - [#567](https://github.com/danger/swift/pull/567)
 
 ## 3.15.0
 

--- a/Sources/Danger/DangerResults.swift
+++ b/Sources/Danger/DangerResults.swift
@@ -17,8 +17,16 @@ public struct Violation: Encodable {
 
 /// Meta information for showing in the text info
 public struct Meta: Encodable {
-    let runtimeName = "Danger Swift"
-    let runtimeHref = "https://danger.systems/swift"
+    let runtimeName: String
+    let runtimeHref: String
+
+    public init(
+        runtimeName: String = "Danger Swift",
+        runtimeHref: String = "https://danger.systems/swift"
+    ) {
+        self.runtimeName = runtimeName
+        self.runtimeHref = runtimeHref
+    }
 }
 
 // MARK: - Results
@@ -38,5 +46,5 @@ struct DangerResults: Encodable {
     var markdowns = [Violation]()
 
     /// Information to pass back to Danger JS about the runtime
-    let meta = Meta()
+    var meta = Meta()
 }

--- a/Sources/Danger/Report.swift
+++ b/Sources/Danger/Report.swift
@@ -37,6 +37,7 @@ func resetDangerResults() {
     globalResults.fails = []
     globalResults.warnings = []
     globalResults.markdowns = []
+    globalResults.meta = Meta()
 }
 
 public extension DangerDSL {
@@ -58,6 +59,11 @@ public extension DangerDSL {
     /// Markdowns on the Danger report
     var markdowns: [Violation] {
         globalResults.markdowns
+    }
+
+    /// Meta information on the Danger report
+    var meta: Meta {
+        globalResults.meta
     }
 
     /// Adds a warning message to the Danger report
@@ -124,6 +130,11 @@ public extension DangerDSL {
 
         globalResults.markdowns.append(Violation(message: message, file: file, line: line))
     }
+
+    /// Changes the meta information that will be passed back to Danger JS about this runtime
+    func meta(_ meta: Meta) {
+        globalResults.meta = meta
+    }
 }
 
 /// Fails on the Danger report
@@ -144,6 +155,11 @@ public var messages: [Violation] {
 /// Markdowns on the Danger report
 public var markdowns: [Violation] {
     globalResults.markdowns
+}
+
+/// Meta information on the Danger report
+var meta: Meta {
+    globalResults.meta
 }
 
 /// Adds a warning message to the Danger report
@@ -197,4 +213,9 @@ public func markdown(message: String, file: String, line: Int) {
 /// Adds an inline suggestion to the Danger report (sends a normal message if suggestions are not supported)
 public func suggestion(code: String, file: String, line: Int) {
     dangerRunner.dsl.suggestion(code: code, file: file, line: line)
+}
+
+/// Changes the meta information that will be passed back to Danger JS about this runtime
+func meta(_ meta: Meta) {
+    dangerRunner.dsl.meta(meta)
 }

--- a/Tests/DangerTests/DangerDSLTests.swift
+++ b/Tests/DangerTests/DangerDSLTests.swift
@@ -25,6 +25,14 @@ final class DangerDSLTests: XCTestCase {
         XCTAssertEqual(danger.warnings.count, 1)
         XCTAssertEqual(danger.fails.count, 1)
     }
+    
+    func testDangerMetaResults() throws {
+       let danger = githubFixtureDSL
+       danger.meta(Meta(runtimeName: "Foo", runtimeHref: "https://foo.com"))
+
+       XCTAssertEqual(danger.meta.runtimeName, "Foo")
+       XCTAssertEqual(danger.meta.runtimeHref, "https://foo.com")
+   }
 
     func testGithubFixtureDSL() throws {
         let danger: DangerDSL = githubFixtureDSL


### PR DESCRIPTION
As discussed in https://github.com/danger/swift/issues/559 there is a need to change the meta information.

Now meta information can be changed with 👇 :
```swift
dsl.meta(
    Meta(
        runtimeName: "💙 Walle",
        runtimeHref: "https://example.com"
    )
)
```

<img width="407" alt="CleanShot 2023-01-26 at 02 11 10@2x" src="https://user-images.githubusercontent.com/14034942/214722730-871a32f2-eef8-4dd1-838f-482607c4425d.png">
