### PR TITLE
GitLab Add deactivated user status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Gitlab Error in merge request with estimate or spent time [@oscarcv][] - [#548](https://github.com/danger/swift/pull/548)
 - Add ability to change meta information [@Nikoloutsos][] - [#567](https://github.com/danger/swift/pull/567)
+- Add deactivated user status for GitLab [@antigp][] - [#572](https://github.com/danger/swift/pull/572)
 
 ## 3.15.0
 

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -270,6 +270,7 @@ public extension GitLab {
         public enum State: String, Decodable {
             case active
             case blocked
+            case deactivated
         }
 
         public let avatarUrl: String?


### PR DESCRIPTION
I added "deactivated" status to user. Because GitLab can return this status in reviewers array. 
Otherwise it fail to decode all dsl json.