### PR TITLE
Update SwiftLint (0.50.3) version in Dockerfile used in `danger-swift-with-swiftlint` container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 
+- Update `SwiftLint` used by `danger-swift-with-swiftlint` from v0.46.1 to [0.50.3](https://github.com/realm/SwiftLint/releases/tag/0.50.3) - [#573](https://github.com/danger/swift/pull/573)
 - Gitlab Error in merge request with estimate or spent time [@oscarcv][] - [#548](https://github.com/danger/swift/pull/548)
 - Resolve `// fileImport: ~` path to an absolute path on running `danger-swift edit` [@417-72KI][] - [#565](https://github.com/danger/swift/pull/565)
 - Add ability to change meta information [@Nikoloutsos][] - [#567](https://github.com/danger/swift/pull/567)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -q \
     && rm -r /var/lib/apt/lists/*
 
 
-# RUN git clone -b 0.46.1 --single-branch --depth 1 https://github.com/realm/SwiftLint.git _swiftlint && cd _swiftlint && git submodule update --init --recursive && make install && rm -rf _swiftlint # swiftlint
+# RUN git clone -b 0.50.3 --single-branch --depth 1 https://github.com/realm/SwiftLint.git _swiftlint && cd _swiftlint && git submodule update --init --recursive && make install && rm -rf _swiftlint # swiftlint
 
 # Install danger-swift globally
 COPY . _danger-swift


### PR DESCRIPTION
This PR aims to update SwiftLint to version `0.50.3` used in `danger-swift-with-swiftlint` docker container.

> SwiftLint release: https://github.com/realm/SwiftLint/releases/tag/0.50.3 