### PR TITLE
GitLab squash attribute for merge request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Resolve `// fileImport: ~` path to an absolute path on running `danger-swift edit` [@417-72KI][] - [#565](https://github.com/danger/swift/pull/565)
 - Add ability to change meta information [@Nikoloutsos][] - [#567](https://github.com/danger/swift/pull/567)
 - Add deactivated user status for GitLab [@antigp][] - [#572](https://github.com/danger/swift/pull/572)
+- Add `squash` attribute for GitLab merge request [@aserdobintsev][] - [#576](https://github.com/danger/swift/pull/576)
 
 ## 3.15.0
 
@@ -554,3 +555,4 @@ This release also includes:
 [danger-swift-with-swiftlint]: https://github.com/orgs/danger/packages/container/package/danger-swift-with-swiftlint
 [@dahlborn]: https://github.com/dahlborn
 [@mxsc]: https://github.com/mxsc
+[@aserdobintsev]: https://github.com/aserdobintsev

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -193,6 +193,7 @@ public extension GitLab {
             case shouldRemoveSourceBranch = "should_remove_source_branch"
             case sourceBranch = "source_branch"
             case sourceProjectId = "source_project_id"
+            case squash
             case state
             case subscribed
             case targetBranch = "target_branch"
@@ -237,6 +238,7 @@ public extension GitLab {
         public let shouldRemoveSourceBranch: Bool?
         public let sourceBranch: String
         public let sourceProjectId: Int
+        public let squash: Bool?
         public let state: State
         public let subscribed: Bool
         public let targetBranch: String

--- a/Tests/DangerTests/GitLabTests.swift
+++ b/Tests/DangerTests/GitLabTests.swift
@@ -78,6 +78,7 @@ final class GitLabTests: XCTestCase {
         XCTAssertNil(mergeRequest.shouldRemoveSourceBranch)
         XCTAssertEqual(mergeRequest.sourceBranch, "patch-2")
         XCTAssertEqual(mergeRequest.sourceProjectId, 10_132_593)
+        XCTAssertEqual(mergeRequest.squash, false)
         XCTAssertEqual(mergeRequest.state, .merged)
         XCTAssertEqual(mergeRequest.subscribed, false)
         XCTAssertEqual(mergeRequest.targetBranch, "master")


### PR DESCRIPTION
Added the GitLab **squash** attribute for merge request.

Attriute | Type | Description
-- | -- | --
squash | boolean | Indicates if squash on merge is enabled.

https://docs.gitlab.com/ee/api/merge_requests.html#response

<img width="456" alt="squash" src="https://user-images.githubusercontent.com/5861270/221533546-178778b5-c085-4731-9f95-b06d38a2d24e.png">

P.S. [DSLGitLabMilestoneNoDateRangeJSON](https://github.com/danger/swift/blob/master/Sources/DangerFixtures/DangerDSLResources/DangerDSLGitLabMilestoneNoDateRange.swift) and [DSLGitLabJSON](https://github.com/danger/swift/blob/master/Sources/DangerFixtures/DangerDSLResources/DangerDSLGitLab.swift) fixtures already contain **squash** attribute.