### PR TITLE
Prevent empty SwiftLint violation response from failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Prevent empty SwiftLint violation response from failure [@pouyayarandi][]
+
 ## 3.17.1
 
 - Use http tap url on update homebrew script [@f-meloni][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-- Prevent empty SwiftLint violation response from failure [@pouyayarandi][]
+- Prevent empty SwiftLint violation response from failure [@pouyayarandi][] - [#596](https://github.com/danger/swift/pull/596)
 
 ## 3.17.1
 

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -307,6 +307,9 @@ extension SwiftLint {
     }
 
     private static func makeViolations(from response: String, failAction: (String) -> Void) -> [SwiftLintViolation] {
+        guard !response.isEmpty else {
+            return []
+        }
         let decoder = JSONDecoder()
         do {
             let violations = try decoder.decode([SwiftLintViolation].self, from: Data(response.utf8))


### PR DESCRIPTION
### Problem
In some cases like empty merge request (merge request with no changes) SwiftLint fails as its response is empty and JSONDecoder got `Unexpected end of file` error.
```
Error deserializing SwiftLint JSON response (): dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected end of file" UserInfo={NSDebugDescription=Unexpected end of file})))
```
### Solution
This PR solves the issue with checking whether response is empty or not. If the response is empty it bypasses decoding and returns an empty array of violations.