### PR TITLE
Fix decoding error for gitlab user

### DIFF
--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -273,6 +273,7 @@ public extension GitLab {
             case active
             case blocked
             case deactivated
+            case ldapBlocked = "ldap_blocked"
         }
 
         public let avatarUrl: String?


### PR DESCRIPTION
### Problem

In some cases in which the LDAP user is blocked from Gitlab, danger gives a decoding error because that state is unsatisfied.

**Example User Response:**

`{
       "id": XXX,
       "username": "xxx.xxx",
       "name": "XXX XXX",
       "state": "ldap_blocked",
       "avatar_url": "https://secure.gravatar.com/avatar/{avatar.id}?s=80&d=identicon",
       "web_url": "https://gitlab.example.com/xxx.xxx"
   }`
   
**Example Curl:**

`curl --location 'https://gitlab.example.com/api/v4/projects/{projectId}/merge_requests/{mergeRequestId}' \
--header 'Content-Type: application/json' \
--header 'PRIVATE-TOKEN: {TOKEN}'`

<img src="https://github.com/danger/swift/assets/53167930/3034810f-e473-45bd-b37e-69e0a0779624" width="300">

### Solution
Added a case to the user's 'state' enum to decode that state correctly.

`case ldapBlocked = "ldap_blocked"`