### PR TITLE
Update Node version to 18.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "com.github.actions.color"="blue"
 # Install nodejs and Danger
 RUN apt-get update -q \
     && apt-get install -qy curl make ca-certificates \
-    && curl -sL https://deb.nodesource.com/setup_10.x |  bash - \
+    && curl -sL https://deb.nodesource.com/setup_18.x |  bash - \
     && apt-get install -qy nodejs \
     && npm install -g danger \
     && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Workflow action started failing after [danger-js](https://github.com/danger/danger-js) dropped support for node older than 18. 

This is the error I've been getting and from what I've seen this started when danger-js@12.0.1 was released.

![B30AFCEC-DDBA-415C-8A1B-D477383F85BD_4_5005_c](https://github.com/danger/swift/assets/3469144/43a17729-79b6-44f2-b36b-c337548e31c0)
