### PR TITLE
Allow optional GitLab MR description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Allow optional GitLab MR description [@kvvzr][] - [#609](https://github.com/danger/swift/pull/609)
+
 ## 3.18.1
 
 - Update Node version to 18.x [@hasanabuzayed][] - [#607](https://github.com/danger/swift/pull/607)

--- a/Sources/Danger/GitLabDSL.swift
+++ b/Sources/Danger/GitLabDSL.swift
@@ -216,7 +216,7 @@ public extension GitLab {
         public let changesCount: String
         public let closedAt: Date?
         public let closedBy: User?
-        public let description: String
+        public let description: String?
         public let diffRefs: DiffRefs
         public let downvotes: Int
         public let firstDeployedToProductionAt: Date?


### PR DESCRIPTION
Similar to this issue, Merge Request description in GitLab can also be nil: https://github.com/danger/swift/pull/73