### PR TITLE
Fix pattern for detecting SwiftLint in package

### DIFF
--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -253,7 +253,7 @@ extension SwiftLint {
     }
 
     static func swiftlintDefaultPath(packagePath: String = "Package.swift") -> String {
-        let swiftPackageDepPattern = #"\.package\(.*SwiftLint.*"#
+        let swiftPackageDepPattern = #"\.package\(.*SwiftLint(\.git)?".*"#
         if let packageContent = try? String(contentsOfFile: packagePath),
            let regex = try? NSRegularExpression(pattern: swiftPackageDepPattern, options: .allowCommentsAndWhitespace),
            regex.firstMatchingString(in: packageContent) != nil {


### PR DESCRIPTION
Danger-Swift uses SwiftLint in the package when it contains, which takes too much times to fetch and build.
There is a repo which only contains plugins (https://github.com/SimplyDanny/SwiftLintPlugins), `swift run swiftlint` is fail when the package conatins it instead of SwiftLint directly.
However, current spec causes failure ( try to run `swift run swiftlint` and fail ) because 
```
.package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "<version>"),
```
matches to 
```
/\.package\(.*SwiftLint.*/
```

This PR fixes a regex to avoid false positive of `SwiftLintPlugins`.

This is a test case
<img width="722" alt="image" src="https://github.com/user-attachments/assets/a117bd3b-b667-42c3-929e-c188f41e8995">
