### PR TITLE
Remove deprecated `lint` function with `lintAllFiles` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 -->
 
 ## Master
+- Remove deprecated `lint` function with `lintAllFiles` flag [@417-72KI][] - [#622](https://github.com/danger/swift/pull/622)
 
 ## 3.19.1
 
-- Expose markdownKit on Swiftlint.lint() for customizing the output [@nikoloutsos][] - [#609](https://github.com/danger/swift/pull/609)
+- Expose markdownKit on Swiftlint.lint() for customizing the output [@nikoloutsos][] - [#610](https://github.com/danger/swift/pull/610)
 - Drop Swift 5.7 [@417-72KI][] - [#620](https://github.com/danger/swift/pull/620)
 - Fix pattern for detecting SwiftLint in package [@417-72KI][] - [#616](https://github.com/danger/swift/pull/616)
 - Allow optional GitLab MR description [@kvvzr][] - [#609](https://github.com/danger/swift/pull/609)

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -37,32 +37,6 @@ public enum SwiftLint {
     static let danger = Danger()
     static let shellExecutor = ShellExecutor()
 
-    /// This method is obsoleted in favor of
-    @available(*, unavailable, message: "Use the lint(_ lintStyle ..) method instead.")
-    @discardableResult
-    public static func lint(inline: Bool = false,
-                            directory: String? = nil,
-                            configFile: String? = nil,
-                            strict: Bool = false,
-                            quiet: Bool = true,
-                            lintAllFiles: Bool = false,
-                            swiftlintPath: String? = nil) -> [SwiftLintViolation] {
-        let lintStyle: LintStyle = {
-            if lintAllFiles {
-                return .all(directory: directory)
-            } else {
-                return .modifiedAndCreatedFiles(directory: directory)
-            }
-        }()
-
-        return lint(lintStyle,
-                    inline: inline,
-                    configFile: configFile,
-                    strict: strict,
-                    quiet: quiet,
-                    swiftlintPath: swiftlintPath)
-    }
-
     /// When the swiftlintPath is not specified,
     /// it uses by default swift run swiftlint if the Package.swift in your root folder contains swiftlint as dependency,
     /// otherwise calls directly the swiftlint command

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -47,14 +47,14 @@ public enum SwiftLint {
                             configFile: String? = nil,
                             strict: Bool = false,
                             quiet: Bool = true,
-                            swiftlintPath: String?,
+                            swiftlintPath: String,
                             markdownAction: (String) -> Void = markdown) -> [SwiftLintViolation] {
         lint(lintStyle,
              inline: inline,
              configFile: configFile,
              strict: strict,
              quiet: quiet,
-             swiftlintPath: swiftlintPath.map(SwiftlintPath.bin),
+             swiftlintPath: .bin(swiftlintPath),
              markdownAction: markdownAction)
     }
 

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -37,8 +37,8 @@ public enum SwiftLint {
     static let danger = Danger()
     static let shellExecutor = ShellExecutor()
 
-    /// This method is deprecated in favor of
-    @available(*, deprecated, message: "Use the lint(_ lintStyle ..) method instead.")
+    /// This method is obsoleted in favor of
+    @available(*, unavailable, message: "Use the lint(_ lintStyle ..) method instead.")
     @discardableResult
     public static func lint(inline: Bool = false,
                             directory: String? = nil,

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -73,13 +73,15 @@ public enum SwiftLint {
                             configFile: String? = nil,
                             strict: Bool = false,
                             quiet: Bool = true,
-                            swiftlintPath: String?) -> [SwiftLintViolation] {
+                            swiftlintPath: String?,
+                            markdownAction: (String) -> Void = markdown) -> [SwiftLintViolation] {
         lint(lintStyle,
              inline: inline,
              configFile: configFile,
              strict: strict,
              quiet: quiet,
-             swiftlintPath: swiftlintPath.map(SwiftlintPath.bin))
+             swiftlintPath: swiftlintPath.map(SwiftlintPath.bin),
+             markdownAction: markdownAction)
     }
 
     /// This is the main entry point for linting Swift in PRs.


### PR DESCRIPTION
Resolves: #621 

Additionaly, it makes `markdownAction` (added in #610) available to use in overloads.