### PR TITLE
Fix: `GitHub.Review.submittedAt` may be `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 - Remove deprecated `lint` function with `lintAllFiles` flag [@417-72KI][] - [#622](https://github.com/danger/swift/pull/622)
+- Fix: `GitHub.Review.submittedAt` may be `nil` [@417-72KI][] - [#624](https://github.com/danger/swift/pull/624)
 
 ## 3.19.1
 

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -323,8 +323,8 @@ public extension GitHub {
         /// The state of the review (if a review was made).
         public let state: State?
 
-        /// The date when the review was submitted
-        public let submittedAt: Date
+        /// The date when the review was submitted (if a review was made).
+        public let submittedAt: Date?
 
         /// The user who has completed the review or has been requested to review.
         public let user: User


### PR DESCRIPTION
`submittedAt` property on some review objects may be `nil` before submitted.
ref: https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#get-a-review-for-a-pull-request
