### PR TITLE
Remove deprecated --path param for swiftlint

### DIFF
--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -185,7 +185,7 @@ extension SwiftLint {
         var arguments = arguments
 
         if let directory = directory {
-            arguments.append("--path \"\(directory)\"")
+            arguments.append(" \"\(directory)\"")
         }
 
         return swiftlintViolations(swiftlintPath: swiftlintPath,

--- a/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
+++ b/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift
@@ -185,7 +185,7 @@ extension SwiftLint {
         var arguments = arguments
 
         if let directory = directory {
-            arguments.append(" \"\(directory)\"")
+            arguments.append(directory)
         }
 
         return swiftlintViolations(swiftlintPath: swiftlintPath,

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -268,7 +268,7 @@ final class DangerSwiftLintTests: XCTestCase {
         XCTAssertNotNil(swiftlintCommand)
         XCTAssertEqual(swiftlintCommand!.environmentVariables.count, 0)
         XCTAssertFalse(swiftlintCommand!.environmentVariables.values.contains { $0.contains("Tests/SomeFile.swift") })
-        XCTAssertTrue(swiftlintCommand!.arguments.contains("--path \"Tests\""))
+        XCTAssertEqual(swiftlintCommand!.arguments.last, directory))
     }
 
     func testFiltersOnSwiftFiles() {

--- a/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
+++ b/Tests/DangerTests/SwiftLint/DangerSwiftLintTests.swift
@@ -268,7 +268,7 @@ final class DangerSwiftLintTests: XCTestCase {
         XCTAssertNotNil(swiftlintCommand)
         XCTAssertEqual(swiftlintCommand!.environmentVariables.count, 0)
         XCTAssertFalse(swiftlintCommand!.environmentVariables.values.contains { $0.contains("Tests/SomeFile.swift") })
-        XCTAssertEqual(swiftlintCommand!.arguments.last, directory))
+        XCTAssertEqual(swiftlintCommand!.arguments.last, directory)
     }
 
     func testFiltersOnSwiftFiles() {


### PR DESCRIPTION
Using a path directory now fails with an error, the `--path` parameter has been [deprecated since 0.48.0 2 years ago](https://github.com/realm/SwiftLint/releases/tag/0.48.0)

Fixes #617