### PR TITLE
Fix module path for Swift 6 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Master
 - Remove deprecated `lint` function with `lintAllFiles` flag [@417-72KI][] - [#622](https://github.com/danger/swift/pull/622)
+- Updated Swift 6 build process: Danger files moved to .build/debug/Modules, and SwiftFormat module map conflict resolved by adjusting the Swift import search path. [@abhi-m-simformsolutons][] -[#626](https://github.com/danger/swift/pull/626)
 
 ## 3.19.1
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -60,7 +60,7 @@ func runDanger(version dangerSwiftVersion: String, logger: Logger) throws {
     if let spmDanger = SPMDanger() {
         spmDanger.buildDependencies(executor: executor)
         libArgs += ["-L", spmDanger.buildFolder]
-        libArgs += ["-I", spmDanger.buildFolder]
+        libArgs += ["-I", spmDanger.moduleFolder]
         libArgs += [spmDanger.swiftcLibImport]
     } else {
         guard let libDangerPath = Runtime.getLibDangerPath() else {

--- a/Sources/RunnerLib/SPMDanger.swift
+++ b/Sources/RunnerLib/SPMDanger.swift
@@ -10,6 +10,14 @@ public struct SPMDanger {
         fileManager.currentDirectoryPath + "/.build/debug"
     }
 
+    public var moduleFolder: String {
+        #if compiler(<6.0)
+            buildFolder
+        #else
+            buildFolder + "/Modules"
+        #endif
+    }
+
     public init?(
         packagePath: String = "Package.swift",
         readFile: (String) -> String? = { try? String(contentsOfFile: $0) },


### PR DESCRIPTION
When building with swift 6, Danger's
- Danger*.abi.json
- __Danger*.swiftmodule__
- Danger*.swiftdoc
- Danger*.swiftsourceinfo 

are now located in `.build/debug/Modules` location instead of `.build/debug/` module.

With swift 6 `SwiftFormat` generates two module maps `SwiftFormat.build` & `SwiftFormat-tool.build`. at `.build/debug/`. Which cause `- error: redefinition of module 'SwiftFormat'`

This change conditionally update swift's import search path to `.build/debug/Modules` to address both issues.

Related issues:
#615 
#623 
