### PR TITLE
Merge duplicated imports in finally-generated Dangerfile

### DIFF
--- a/DangerfileExtensions/ChangelogCheck.swift
+++ b/DangerfileExtensions/ChangelogCheck.swift
@@ -1,3 +1,5 @@
+import Danger
+
 func checkChangelog() {
     let allSourceFiles = danger.git.modifiedFiles + danger.git.createdFiles
 

--- a/Sources/RunnerLib/Files Import/DangerFileGenerator.swift
+++ b/Sources/RunnerLib/Files Import/DangerFileGenerator.swift
@@ -33,10 +33,16 @@ public final class DangerFileGenerator {
 
 private extension DangerFileGenerator {
     func mergeImports(in content: inout String) {
-        var lines = content.split(separator: "\n",
-                                  omittingEmptySubsequences: false)
-        let imports = Set(lines.filter { $0.hasPrefix("import ") })
-        lines.removeAll { imports.contains($0) }
+        var lines = content
+            .split(separator: "\n",
+                   omittingEmptySubsequences: false)
+            .map(String.init)
+
+        let imports = Set(
+            lines.map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { $0.hasPrefix("import ") }
+        )
+        lines.removeAll { imports.contains($0.trimmingCharacters(in: .whitespaces)) }
         lines.insert(contentsOf: imports.sorted(), at: 0)
         content = lines.joined(separator: "\n")
     }

--- a/Sources/RunnerLib/Files Import/DangerFileGenerator.swift
+++ b/Sources/RunnerLib/Files Import/DangerFileGenerator.swift
@@ -25,6 +25,19 @@ public final class DangerFileGenerator {
             dangerContent.replaceSubrange(replacementRange, with: fileContent)
         })
 
+        mergeImports(in: &dangerContent)
+
         try dangerContent.write(toFile: fileName, atomically: false, encoding: .utf8)
+    }
+}
+
+private extension DangerFileGenerator {
+    func mergeImports(in content: inout String) {
+        var lines = content.split(separator: "\n",
+                                  omittingEmptySubsequences: false)
+        let imports = Set(lines.filter { $0.hasPrefix("import ") })
+        lines.removeAll { imports.contains($0) }
+        lines.insert(contentsOf: imports.sorted(), at: 0)
+        content = lines.joined(separator: "\n")
     }
 }

--- a/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
+++ b/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
@@ -43,7 +43,11 @@ final class DangerFileGeneratorTests: XCTestCase {
     }
 
     func testItGeneratesTheCorrectFileWhenThereAreNoImports() throws {
-        try generator.generateDangerFile(fromContent: contentWithoutImports, fileName: generatedFilePath, logger: logger)
+        try generator.generateDangerFile(
+            fromContent: headerForContentWithoutImports + contentWithoutImports,
+            fileName: generatedFilePath,
+            logger: logger
+        )
 
         try assertSnapshot(matching: generatedContent(), as: .lines)
     }
@@ -86,6 +90,14 @@ final class DangerFileGeneratorTests: XCTestCase {
 }
 
 extension DangerFileGeneratorTests {
+    private var headerForContentWithoutImports: String {
+        """
+        import Danger
+
+        let danger = Danger()
+        """ + "\n\n"
+    }
+
     private var contentWithoutImports: String {
         """
         message("Text")

--- a/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
+++ b/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
@@ -87,6 +87,18 @@ final class DangerFileGeneratorTests: XCTestCase {
 
         try assertSnapshot(matching: generatedContent(), as: .lines)
     }
+
+    func testItGeneratesTheCorrectFileWhenThereIsAreImportsWithIndent() throws {
+        try? file2Content.write(toFile: file2Path, atomically: true, encoding: .utf8)
+        try? file3Content.write(toFile: file3Path, atomically: true, encoding: .utf8)
+
+        createdFiles.append(file2Path)
+        createdFiles.append(file3Path)
+
+        try generator.generateDangerFile(fromContent: contentWithImportsWithIndent, fileName: generatedFilePath, logger: logger)
+
+        try assertSnapshot(matching: generatedContent(), as: .lines)
+    }
 }
 
 extension DangerFileGeneratorTests {
@@ -115,6 +127,16 @@ extension DangerFileGeneratorTests {
         "// fileImport: " + file2Path + "\n\n"
             + "// fileImport: " + file3Path + "\n"
             + contentWithOneImport
+    }
+
+    private var contentWithImportsWithIndent: String {
+        headerForContentWithoutImports
+            + "if flag {\n"
+            + "    // fileImport: " + file2Path + "\n"
+            + "} else {\n"
+            + "    // fileImport: " + file3Path + "\n"
+            + "}\n"
+            + contentWithoutImports
     }
 
     private var file1Content: String {

--- a/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
+++ b/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
@@ -106,7 +106,9 @@ extension DangerFileGeneratorTests {
     }
 
     private var contentWithOneImport: String {
-        "// fileImport: " + file1Path + "\n" + contentWithoutImports
+        headerForContentWithoutImports
+            + "// fileImport: " + file1Path + "\n"
+            + contentWithoutImports
     }
 
     private var contentWithMultipleImports: String {

--- a/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
+++ b/Tests/RunnerLibTests/DangerFileGeneratorTests.swift
@@ -112,8 +112,9 @@ extension DangerFileGeneratorTests {
     }
 
     private var contentWithMultipleImports: String {
-        "// fileImport: " + file2Path + "\n\n" +
-            "// fileImport: " + file3Path + "\n" + contentWithOneImport
+        "// fileImport: " + file2Path + "\n\n"
+            + "// fileImport: " + file3Path + "\n"
+            + contentWithOneImport
     }
 
     private var file1Content: String {
@@ -125,12 +126,17 @@ extension DangerFileGeneratorTests {
 
     private var file2Content: String {
         """
+        import Danger
+        
         file2Content ⚠️
         """
     }
 
     private var file3Content: String {
         """
+        import Danger
+        import Foundation
+        
         file3Content 👩‍👩‍👦‍👦
         secondLine
         really really really really really really really really really really really really \

--- a/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenOneOfTheImportedFilesIsMissing.1.txt
+++ b/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenOneOfTheImportedFilesIsMissing.1.txt
@@ -1,6 +1,11 @@
+import Danger
+
 file2Content ⚠️
 
 // fileImport: GeneratedTestFile3.swift
+
+let danger = Danger()
+
 file1Content 👍🏻
 secondLine
 message("Text")

--- a/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereAreNoImports.1.txt
+++ b/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereAreNoImports.1.txt
@@ -1,2 +1,6 @@
+import Danger
+
+let danger = Danger()
+
 message("Text")
 message("Another Text")

--- a/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsASingleImport.1.txt
+++ b/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsASingleImport.1.txt
@@ -1,3 +1,7 @@
+import Danger
+
+let danger = Danger()
+
 file1Content 👍🏻
 secondLine
 message("Text")

--- a/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsAreImportsWithIndent.1.txt
+++ b/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsAreImportsWithIndent.1.txt
@@ -1,0 +1,16 @@
+import Danger
+import Foundation
+
+let danger = Danger()
+
+if flag {
+
+file2Content ⚠️
+} else {
+
+file3Content 👩‍👩‍👦‍👦
+secondLine
+really really really really really really really really really really really really really really really really really really really really really really long text
+}
+message("Text")
+message("Another Text")

--- a/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsAreMultipleImports.1.txt
+++ b/Tests/RunnerLibTests/__Snapshots__/DangerFileGeneratorTests/testItGeneratesTheCorrectFileWhenThereIsAreMultipleImports.1.txt
@@ -1,8 +1,15 @@
+import Danger
+import Foundation
+
 file2Content ⚠️
+
 
 file3Content 👩‍👩‍👦‍👦
 secondLine
 really really really really really really really really really really really really really really really really really really really really really really long text
+
+let danger = Danger()
+
 file1Content 👍🏻
 secondLine
 message("Text")


### PR DESCRIPTION
Dividing files using `// fileImport:` is a very useful feature on Danger-Swift.

However, importing module in extracted file may causes an error.

## Example

### Dangerfile.swift
```swift
import Danger

let danger = Danger()

do {
  // fileImport: DangerExtensions/SomeFeature.swift
  try doSomething(danger, file: "path/to/file")
} catch {
  logger.error(error)
  danger.fail(error.localizedDescription)
}
```

### DangerExtensions/SomeFeature.swift
```swift
import Danger // - error: declaration is only valid at file scope

func doSomething(_ danger: DangerDSL, filePath: String) throws {
  // ...
}
```

This PR makes it to merge duplicated module imports and declare at the top on generated `_tmp_dangerfile.swift`.