### PR TITLE
Fix macOS runner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,9 @@ jobs:
       run: brew install danger/tap/danger-js
 
     - run: make install
-      if: ${{ runner.os == 'macos-13' }}
+      if: ${{ matrix.runner == 'macos-13' }}
     - run: make install PREFIX='/opt/homebrew'
-      if: ${{ runner.os != 'macos-13' }}
+      if: ${{ matrix.runner != 'macos-13' }}
 
     - run: rm -rf .build && rm -rf Package.swift
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-on-macos-13:
-    name: Test on macOS 13
-    runs-on: macOS-13
+  test-on-macos:
+    name: Test on macOS
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["14.3.1"]
+        include:
+          - runner: "macos-13"
+            xcode: "14.3.1"
+          - runner: "macos-14"
+            xcode: "15.4"
+          - runner: "macos-15"
+            xcode: "16.1"
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
 
@@ -50,52 +56,17 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  test-on-macos-14:
-    name: Test on macOS 14
-    runs-on: macOS-14
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode: ["15.4", "16.0"]
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          .build/artifacts
-          .build/checkouts
-          .build/repositories
-        key: ${{ runner.os }}-dependencies-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-dependencies-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
-          ${{ runner.os }}-dependencies-${{ matrix.xcode }}-
-
-    - name: Select Xcode
-      run: |
-        xcodebuild -version
-        ls -nt /Applications/ | grep "Xcode*"
-        sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
-        xcodebuild -version
-
-    - name: Install danger-js
-      run: brew install danger/tap/danger-js
-
-    - run: swift test
-
-    - run: swift run danger-swift ci --verbose --failOnErrors
-      if: ${{ github.event_name == 'pull_request' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   test-dependencies-resolver:
     name: Test dependencies resolver
-    runs-on: macOS-14
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["15.4", "16.0"]
+        include:
+          - runner: "macos-14"
+            xcode: "15.4"
+          - runner: "macos-15"
+            xcode: "16.1"
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
 
@@ -169,13 +140,19 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
-  test-without-spm-on-macos-13:
-    name: Test without SPM on macOS 13
-    runs-on: macOS-13
+  test-without-spm-on-macos:
+    name: Test without SPM on macOS
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["14.3.1"]
+        include:
+          - runner: "macos-13"
+            xcode: "14.3.1"
+          - runner: "macos-14"
+            xcode: "15.4"
+          - runner: "macos-15"
+            xcode: "16.1"
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
 
@@ -202,47 +179,9 @@ jobs:
       run: brew install danger/tap/danger-js
 
     - run: make install
-
-    - run: rm -rf .build && rm -rf Package.swift
-
-    - run: danger-swift ci --verbose --failOnErrors
-      if: ${{ github.event_name == 'pull_request' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  test-without-spm-on-macos-14:
-    name: Test without SPM on macOS 14
-    runs-on: macOS-14
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode: ["15.4", "16.0"]
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          .build/artifacts
-          .build/checkouts
-          .build/repositories
-        key: ${{ runner.os }}-without-spm-package-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-without-spm-package-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
-          ${{ runner.os }}-without-spm-package-${{ matrix.xcode }}-
-
-    - name: Select Xcode
-      run: |
-        xcodebuild -version
-        ls -nt /Applications/ | grep "Xcode*"
-        sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
-        xcodebuild -version
-
-    - name: Install danger-js
-      run: brew install danger/tap/danger-js
-
+      if: ${{ runner.os == 'macos-13' }}
     - run: make install PREFIX='/opt/homebrew'
+      if: ${{ runner.os != 'macos-13' }}
 
     - run: rm -rf .build && rm -rf Package.swift
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         swift: ["5.9", "5.10", "6.0"]
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
 
     - name: Cache dependencies
       uses: actions/cache@v4
@@ -199,7 +199,7 @@ jobs:
         swift: ["5.9", "5.10", "6.0"]
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .build/artifacts
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .build/artifacts
@@ -113,7 +113,7 @@ jobs:
     - uses: actions/setup-node@v2
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .build/artifacts
@@ -157,7 +157,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .build/artifacts
@@ -202,7 +202,7 @@ jobs:
     - uses: actions/setup-node@v2
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .build/artifacts


### PR DESCRIPTION
GitHub has a policy changes and make it to contain only 1 major version in 1 runner.
ref: https://github.com/actions/runner-images/issues/10703

This PR extracts runner into the matrix and unify duplicated jobs divided per runners.