### PR TITLE
Replace deprecated properties and functions in `Process`

### DIFF
--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Logger
 import RunnerLib
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger) throws -> Int32 {
     guard let dangerJS = try? getDangerCommandPath(logger: logger) else {
@@ -22,7 +25,7 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
 
     let proc = Process()
     proc.environment = ProcessInfo.processInfo.environment
-    proc.launchPath = dangerJS
+    proc.executableURL = URL(fileURLWithPath: dangerJS)
 
     let dangerOptionsIndexes = DangerSwiftOption.allCases
         .compactMap { option -> (DangerSwiftOption, Int)? in
@@ -62,8 +65,8 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
     proc.standardOutput = standardOutput
     proc.standardError = standardOutput
 
-    logger.debug("Running: \(proc.launchPath!) \(proc.arguments!.joined(separator: " ")) ")
-    proc.launch()
+    logger.debug("Running: \(proc.executableURL!) \(proc.arguments!.joined(separator: " ")) ")
+    try proc.run()
     proc.waitUntilExit()
 
     return proc.terminationStatus

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -3,6 +3,9 @@ import DangerShellExecutor
 import Foundation
 import Logger
 import RunnerLib
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 // swiftlint:disable:next function_body_length
 func runDanger(version dangerSwiftVersion: String, logger: Logger) throws {
@@ -152,19 +155,19 @@ func runDanger(version dangerSwiftVersion: String, logger: Logger) throws {
 
     // Create a process to eval the Swift file
     let proc = Process()
-    proc.launchPath = swiftC
+    proc.executableURL = URL(fileURLWithPath: swiftC)
     proc.arguments = args
     let standardOutput = FileHandle.standardOutput
     if let cwdOptionIndex = CommandLine.arguments.firstIndex(of: DangeSwiftRunnerOption.cwd.rawValue),
        (cwdOptionIndex + 1) < CommandLine.arguments.count,
        let directoryURL = URL(string: CommandLine.arguments[cwdOptionIndex + 1])
     {
-        proc.currentDirectoryPath = directoryURL.absoluteString
+        proc.currentDirectoryURL = directoryURL
     }
     proc.standardOutput = standardOutput
     proc.standardError = standardOutput
 
-    proc.launch()
+    try proc.run()
     proc.waitUntilExit()
 
     logger.debug("Completed evaluation")


### PR DESCRIPTION
In linux (Docker image), building Danger-Swift has some warnings.

```sh
Building for debugging...
/work/Sources/Runner/Commands/Edit.swift:20:9: warning: immutable value 'absoluteLibPath' was never used; consider removing it
    let absoluteLibPath: String
        ^
/work/Sources/Runner/Commands/Edit.swift:21:9: warning: immutable value 'libsImport' was never used; consider removing it
    let libsImport: [String]
        ^
/work/Sources/Runner/Commands/Runner.swift:155:10: warning: 'launchPath' is deprecated: renamed to 'executableURL'
    proc.launchPath = swiftC
         ^
/work/Sources/Runner/Commands/Runner.swift:155:10: note: use 'executableURL' instead
    proc.launchPath = swiftC
         ^~~~~~~~~~
         executableURL
/work/Sources/Runner/Commands/Runner.swift:162:14: warning: 'currentDirectoryPath' is deprecated: renamed to 'currentDirectoryURL'
        proc.currentDirectoryPath = directoryURL.absoluteString
             ^
/work/Sources/Runner/Commands/Runner.swift:162:14: note: use 'currentDirectoryURL' instead
        proc.currentDirectoryPath = directoryURL.absoluteString
             ^~~~~~~~~~~~~~~~~~~~
             currentDirectoryURL
/work/Sources/Runner/Commands/Runner.swift:167:10: warning: 'launch()' is deprecated: renamed to 'run'
    proc.launch()
         ^
/work/Sources/Runner/Commands/Runner.swift:167:10: note: use 'run' instead
    proc.launch()
         ^~~~~~
         run
/work/Sources/Runner/Commands/RunDangerJS.swift:25:10: warning: 'launchPath' is deprecated: renamed to 'executableURL'
    proc.launchPath = dangerJS
         ^
/work/Sources/Runner/Commands/RunDangerJS.swift:25:10: note: use 'executableURL' instead
    proc.launchPath = dangerJS
         ^~~~~~~~~~
         executableURL
```

This PR fixes ones that saids `'~' is deprecated`.