### PR TITLE
Android support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add Android support [@marcprux][] - [#635](https://github.com/danger/swift/pull/635)
+
 ## 3.20.2
 
 - Fix install script to work with Swift 6.0 [@f-meloni][] - [#627](https://github.com/danger/swift/pull/628)

--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
+#elseif canImport(Android)
+    import Android
 #else
     import Darwin.C
 #endif


### PR DESCRIPTION
This PR enables Danger to be compiled for Android by fixing the single `Glibc` import to be conditional.