### PR TITLE
Drain stdout and stderr concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 - Add Android support [@marcprux][] - [#635](https://github.com/danger/swift/pull/635)
+- Drain stdout and stderr concurrently [@jflan-dd] - [#636](https://github.com/danger/swift/pull/636)
 
 ## 3.20.2
 

--- a/Sources/DangerShellExecutor/ShellExecutor.swift
+++ b/Sources/DangerShellExecutor/ShellExecutor.swift
@@ -56,7 +56,7 @@ extension ShellExecuting {
 public struct ShellExecutor: ShellExecuting {
     /// Queue used to concurrently listen to both stdout and stderr
     private let outputQueue = DispatchQueue(label: "ShellExecutor.outputQueue", attributes: .concurrent)
-    
+
     public init() {}
 
     public func execute(_ command: String,


### PR DESCRIPTION
Same motivation as https://github.com/danger/swift/pull/614, but for when stderr fills up first.

Can be manually verified using:
```swift
let shell = ShellExecutor()
let result = try shell.spawn("hexdump /dev/urandom | head -c 500000 1>&2", arguments: [])
```
