### PR TITLE
Fix detecting `MAJOR_VERSION` in linux

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     BUILD_FOLDER=".build/debug"
     swift build --disable-sandbox
-    MAJOR_VERSION=$(swift --version | awk '{for(i=1;i<=NF;i++){if($i ~ /^[0-9]+\.[0-9]+\.[0-9]?$/){print $i; break}}}' | cut -d '.' -f 1)
+    MAJOR_VERSION=$(swift --version | awk '{for(i=1;i<=NF;i++){if($i ~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/){print $i; break}}}' | cut -d '.' -f 1)
 fi
 
 mkdir -p "$PREFIX/bin"

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     BUILD_FOLDER=".build/debug"
     swift build --disable-sandbox
-    MAJOR_VERSION=$(swift --version | awk '{for(i=1;i<=NF;i++){if($i ~ /^[0-9]+\.[0-9]+$/){print $i; break}}}' | cut -d '.' -f 1)
+    MAJOR_VERSION=$(swift --version | awk '{for(i=1;i<=NF;i++){if($i ~ /^[0-9]+\.[0-9]+\.[0-9]?$/){print $i; break}}}' | cut -d '.' -f 1)
 fi
 
 mkdir -p "$PREFIX/bin"


### PR DESCRIPTION
When `swift --version` returns like `6.0.3` installation script fails to get `MAJOR_VERSION` and modules are not copied into `LIB_INSTALL_PATH`.