### PR TITLE
fix: absolute URL for correct path resolution in Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+## 3.21.2
+
+- Fix Runner's path resolution to enable `--cwd` with relative paths [@Fab1n][] - [#650](https://github.com/danger/swift/pull/650)
+
 ## 3.21.1
 
 - Fix current directory url creation [@f-meloni][] - [#640](https://github.com/danger/swift/pull/640)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ## 3.21.2
 
-- Fix Runner's path resolution to enable `--cwd` with relative paths [@Fab1n][] - [#650](https://github.com/danger/swift/pull/650)
+- Fix Runner's path resolution to enable `--cwd` with relative paths [@Fab1n](https://github.com/Fab1n) - [#650](https://github.com/danger/swift/pull/650)
 
 ## 3.21.1
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -162,7 +162,7 @@ func runDanger(version dangerSwiftVersion: String, logger: Logger) throws {
        (cwdOptionIndex + 1) < CommandLine.arguments.count
     {
         let directoryURL = URL(fileURLWithPath: CommandLine.arguments[cwdOptionIndex + 1])
-        proc.currentDirectoryURL = directoryURL
+        proc.currentDirectoryURL = directoryURL.absoluteURL
     }
     proc.standardOutput = standardOutput
     proc.standardError = standardOutput


### PR DESCRIPTION
## Problem
The logic when using the `--cwd` parameter has been altered with https://github.com/danger/swift/releases/tag/3.21.0. 

In one of the projects where I am participating we use the Danger Swift in a nested subdir called `scripts/Scripts`.  
Thus we need to make use of the cwd param with `--cwd ../../`. 

This is the error we get since upgrading to a version `>= 3.21.0`:
```
The operation couldn’t be completed. (SwiftLintCore.Issue error 13.)
Could not read configuration: file Configuration.swift, line 274

/bin/sh: line 1: 89322 Abort trap: 6           mise x -- swiftlint lint --reporter json --quiet --config ".swiftlint-danger.yml" > /var/folders/5j/lqqdx5hd6qj66nzrg6bhr_kw0000gq/T/swiftlintReport.json
```

## How to reproduce
To execute the script then we follow your advice [here](https://github.com/danger/swift?tab=readme-ov-file#current-working-directory):
> Note that to do this, you must run danger-swift from the directory where the Package.swift is located

So we literally do this:
```sh
cd scripts/Scripts
swift run danger-swift ci --dangerfile Dangerfile-Preflight.swift --id "Danger Preflight" --failOnErrors --cwd ../../
```
**Notice the `../../` at the end!**

## Why does it happen?
The PR chunk that introduces the breaking change is: https://github.com/danger/swift/pull/634/files#diff-c744a5c86fb867044f963d726549b0df11e03443f10c9d4c21c06103d8f0d534

Here is the PR ref: #634

We switched from:
https://github.com/danger/swift/blob/808ad8403c8aa3091ffffebd9db03495a68a9753/Sources/Runner/Commands/Runner.swift#L158-L163

To:
https://github.com/danger/swift/blob/a820ad08643c0771d18f167f33aa99af141e3eed/Sources/Runner/Commands/Runner.swift#L161-L166

... effectively removing the absolute URL resolution, which especially has an effect if you pass a relative path like `../../`.

## The fix 🔧 

The fix simply is to add the absoluteURL var call: `proc.currentDirectoryURL = directoryURL.absoluteURL`

## Testing
Apply the fix locally via `swift package edit swift` in the Package folder, where the `Danger Swift` dependency has been added by replacing the dependency with:
`.package(url: "https://github.com/Fab1n/danger-swift.git", branch: "runner-fix-absolute-url"),`

This pulls in this PR's change. 

Run:
```sh
swift run danger-swift pr https://github.com/danger/swift/pull/146 --dangerfile Some-Dangerfile.swift --cwd ../../
```

🎉 
