### PR TITLE
Add XCTestPlan file extension to `FileType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-- Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle](https://github.com/gsl-anthonymerle) - [653](https://github.com/danger/swift/pull/653)
+- Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle]() - [#653](https://github.com/danger/swift/pull/653)
 
 ## 3.21.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,5 +624,5 @@ This release also includes:
 [@aserdobintsev]: https://github.com/aserdobintsev
 [@dromerobarria]: https://github.com/dromerobarria
 [@msnazarow]: https://github.com/msnazarow
-[@Davarg]https://github.com/Davarg
+[@Davarg]: https://github.com/Davarg
 [@gsl-anthonymerle]: https://github.com/gsl-anthonymerle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-- Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle]() - [#653](https://github.com/danger/swift/pull/653)
+- Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle][] - [#653](https://github.com/danger/swift/pull/653)
 
 ## 3.21.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle](https://github.com/gsl-anthonymerle) - [653](https://github.com/danger/swift/pull/653)
+
 ## 3.21.2
 
 - Fix Runner's path resolution to enable `--cwd` with relative paths [@Fab1n](https://github.com/Fab1n) - [#650](https://github.com/danger/swift/pull/650)
@@ -623,3 +625,4 @@ This release also includes:
 [@dromerobarria]: https://github.com/dromerobarria
 [@msnazarow]: https://github.com/msnazarow
 [@Davarg]https://github.com/Davarg
+[@gsl-anthonymerle]: https://github.com/gsl-anthonymerle

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -19,7 +19,7 @@ public extension File {
 
 public enum FileType: String, Equatable, CaseIterable {
     // swiftlint:disable:next identifier_name
-    case h, json, m, markdown = "md", mm, pbxproj, plist, storyboard, swift, xcscheme, yaml, yml
+    case h, json, m, markdown = "md", mm, pbxproj, plist, storyboard, swift, xcscheme, yaml, yml, xctestplan
 }
 
 // MARK: - FileType extensions

--- a/Tests/DangerTests/FileTests.swift
+++ b/Tests/DangerTests/FileTests.swift
@@ -129,4 +129,12 @@ final class FileTests: XCTestCase {
 
         XCTAssertEqual(file.fileType, expectedType)
     }
+
+    func test_fileType_forXCTestPlan() {
+        let file: File = "TestPlan.xctestplan"
+
+        let expectedType: FileType = .xctestplan
+
+        XCTassertEqual(file.fileType, expectedType)
+    }
 }

--- a/Tests/DangerTests/FileTests.swift
+++ b/Tests/DangerTests/FileTests.swift
@@ -135,6 +135,6 @@ final class FileTests: XCTestCase {
 
         let expectedType: FileType = .xctestplan
 
-        XCTassertEqual(file.fileType, expectedType)
+        XCTAssertEqual(file.fileType, expectedType)
     }
 }


### PR DESCRIPTION
Xcode can now create `.xctestplan` files, so I added this extension to be able to filter them in Danger Swift