### PR TITLE
Fix arguments for danger-js to avoid discarding URL which contains `danger-swift`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix arguments for danger-js to avoid discarding URL which contains `danger-swift` [@417-72KI][] - [#656](https://github.com/danger/swift/pull/656)
+
 ## 3.22.0
 
 - Add `.xctestplan` extension to available file extensions [@gsl-anthonymerle][] - [#653](https://github.com/danger/swift/pull/653)

--- a/Sources/Runner/Commands/RunDangerJS.swift
+++ b/Sources/Runner/Commands/RunDangerJS.swift
@@ -41,7 +41,7 @@ func runDangerJSCommandToRunDangerSwift(_ command: DangerCommand, logger: Logger
             return nil
         }
 
-        if arg.contains("danger-swift") || arg == command.rawValue {
+        if arg.hasSuffix("danger-swift") || arg == command.rawValue {
             return nil
         }
 


### PR DESCRIPTION
fix: #655 