### PR TITLE
Fix enum case value for mannequin in UserType

### DIFF
--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -198,7 +198,7 @@ public extension GitHub {
             case user = "User"
             case organization = "Organization"
             case bot = "Bot"
-            case mannequin
+            case mannequin = "Mannequin"
         }
 
         /// The UUID for the user organization.


### PR DESCRIPTION
The user type returned from the GitHub API has a different case than what is expected here. 

<img width="3010" height="250" alt="Screenshot 2025-11-13 at 12 15 24 PM" src="https://github.com/user-attachments/assets/4ea0aed5-1127-4e30-8499-e66191c06894" />
