### PR TITLE
Fix macOS CI: brew-installed danger-js embeds a Node <18.17, breaking undici's fetch()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: "macos-13"
-            xcode: "14.3.1"
           - runner: "macos-14"
             xcode: "15.4"
           - runner: "macos-15"
             xcode: "16.1"
+          - runner: "macos-26"
+            xcode: "26.6"
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
@@ -72,6 +72,8 @@ jobs:
             xcode: "15.4"
           - runner: "macos-15"
             xcode: "16.1"
+          - runner: "macos-26"
+            xcode: "26.6"
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
@@ -160,12 +162,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: "macos-13"
-            xcode: "14.3.1"
           - runner: "macos-14"
             xcode: "15.4"
           - runner: "macos-15"
             xcode: "16.1"
+          - runner: "macos-26"
+            xcode: "26.6"
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
         xcodebuild -version
 
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+
     - name: Install danger-js
-      run: brew install danger/tap/danger-js
+      run: |
+        yarn global add danger
+        echo `yarn global bin` >> $GITHUB_PATH
 
     - run: swift test
 
@@ -89,8 +95,14 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
         xcodebuild -version
 
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+
     - name: Install danger-js
-      run: brew install danger/tap/danger-js
+      run: |
+        yarn global add danger
+        echo `yarn global bin` >> $GITHUB_PATH
 
     - run: make install PREFIX='/opt/homebrew'
 
@@ -177,13 +189,16 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
         xcodebuild -version
 
-    - name: Install danger-js
-      run: brew install danger/tap/danger-js
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
 
-    - run: make install
-      if: ${{ matrix.runner == 'macos-13' }}
+    - name: Install danger-js
+      run: |
+        yarn global add danger
+        echo `yarn global bin` >> $GITHUB_PATH
+
     - run: make install PREFIX='/opt/homebrew'
-      if: ${{ matrix.runner != 'macos-13' }}
 
     - run: rm -rf .build && rm -rf Package.swift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-- Fixed macOS CI: the brew-installed `danger-js` binary embeds a Node 18 older than 18.17, which `undici` 6 requires, so every `fetch()` call (including fetching PR files) threw. Install `danger-js` via `setup-node` + `yarn` on macOS instead, matching the already-passing Linux CI. Also retired the `macos-13` legs (that runner image no longer exists) in favor of `macos-26`. [@DylanBettermannDD][]
+- Fixed macOS CI: the brew-installed `danger-js` binary embeds a Node 18 older than 18.17, which `undici` 6 requires, so every `fetch()` call (including fetching PR files) threw. Install `danger-js` via `setup-node` + `yarn` on macOS instead, matching the already-passing Linux CI. Also retired the `macos-13` legs (that runner image no longer exists) in favor of `macos-26`. [@DylanBettermannDD][] - [#664](https://github.com/danger/swift/pull/664)
 
 ## 3.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fixed macOS CI: the brew-installed `danger-js` binary embeds a Node 18 older than 18.17, which `undici` 6 requires, so every `fetch()` call (including fetching PR files) threw. Install `danger-js` via `setup-node` + `yarn` on macOS instead, matching the already-passing Linux CI. Also retired the `macos-13` legs (that runner image no longer exists) in favor of `macos-26`. [@DylanBettermannDD][]
+
 ## 3.22.1
 
 - Fix enum case value for mannequin in UserType [@tahirmt][] - [#659](https://github.com/danger/swift/pull/659)
@@ -634,3 +636,4 @@ This release also includes:
 [@Davarg]: https://github.com/Davarg
 [@gsl-anthonymerle]: https://github.com/gsl-anthonymerle
 [@tahirmt]: https://github.com/tahirmt
+[@DylanBettermannDD]: https://github.com/DylanBettermannDD

--- a/Package.resolved
+++ b/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
-        "version" : "1.17.5"
+        "revision" : "2e6a85b73fc14e27d7542165ae73b1a10516ca9a",
+        "version" : "1.17.7"
       }
     },
     {


### PR DESCRIPTION
## Problem

Every macOS CI leg on PRs to this repo fails, unrelated to what the PR actually changes — including on #662 and my own #663. Swift itself is fine (`swift test` passes 174/174 on macos-15/Xcode 16.1); the job dies in the `danger-swift ci` step, inside `danger-js`:

```
Failed to fetch GitHub pull request files: TypeError: terminated
    at Fetch.onAborted (/snapshot/danger-js/node_modules/undici/lib/web/fetch/index.js:2046:49)
  [cause]: TypeError [ERR_INVALID_ARG_TYPE]: The "stream" argument must be an instance of Stream.
           Received an instance of ReadableStream
      at eos (node:internal/streams/end-of-stream:65:11)
      at fetchFinale (…/undici/lib/web/fetch/index.js:1101:5)
```

## Root cause

`/snapshot/…` is `pkg`'s virtual filesystem — the crash is inside the **brew-installed standalone `danger-js` binary**, which embeds its own Node, not the runner's Node (which is fine — 22/24 on current images):

| Fact | Source |
|---|---|
| macOS jobs install via `brew install danger/tap/danger-js` | `.github/workflows/ci.yml` |
| that formula ships a prebuilt `pkg`-built zip | `danger/homebrew-tap/danger-js.rb` |
| built via `pkg … --targets node18-macos-{x64,arm64}` → embedded **Node 18** | `danger-js` `package.json` |
| `pkg@^5.8.1` → `pkg-fetch@3.4.2`, whose newest Node 18 base is **v18.15.0** | `vercel/pkg` `package.json`; `pkg-fetch` patches tree |
| shipped `danger-js` 13.0.10 pins **`undici` 6.21.1** exactly | `danger-js@13.0.10` `package.json` + `yarn.lock` |
| `undici@6.x` requires `node >=18.17` | its `engines` field |

18.15 < 18.17, so `undici`'s `fetchFinale` hands `stream.finished()` a web `ReadableStream` it doesn't support on that Node, and every `fetch()` throws. This started when `danger-js` switched from `node-fetch` to `undici` (commit `c8b966ae`, shipped in **13.0.10**, 2026-06-25) — consistent with the last green macOS PR run being 2025-09-28.

The Linux jobs never hit this: they already install `danger` from npm via `actions/setup-node` + `yarn global add danger` instead of the brew binary, and pass.

## Fix (4 commits)

1. **Install `danger-js` on macOS the way the Linux jobs already do** — `actions/setup-node@v4` (Node 20.x) + `yarn global add danger`, in all three macOS jobs. This is a verbatim copy of the block `test-on-linux`/`test-without-spm-on-linux` have used successfully for a while, so it inherits their track record rather than being a new install path.
2. **Retire the `macos-13` legs, add `macos-26`.** Both `macos-13` legs sat `queued` for an entire run and never complete — that runner image is gone from `actions/runner-images`. Also removes the now-dead `matrix.runner == 'macos-13'` conditional in `test-without-spm-on-macos`.
3. **Bump `swift-snapshot-testing` 1.17.5 → 1.17.7.** Required for the new `macos-26`/Xcode 26.6 leg: 1.17.5's `SnapshotsTestTrait.swift` fails to compile under Swift 6.3 (`cannot use conformance of 'Never' to 'TestScoping'... imported as implementation-only`); 1.17.7 fixes it. Verified this doesn't silently re-resolve past 1.17.x despite `Package.swift`'s `from: "1.17.0"` — `swift package update swift-snapshot-testing` under Xcode 26.6 lands on exactly 1.17.7, not 1.19.x, so `Package.resolved` alone holds without a tighter manifest bound. Full, unfiltered `swift test` passes 165/165 with this pin.
4. CHANGELOG entry.

## Notes for review

- **Deliberately left unpinned/mutable**, matching the existing Linux jobs exactly rather than unilaterally hardening only the macOS side: `danger` is installed at latest (Linux does the same today), `actions/setup-node@v4` is a mutable major tag (so is every other action in this file), and `yarn global add`/`yarn global bin` are Yarn Classic commands (also already relied on by the Linux jobs, which have no `package.json`/Corepack in this repo to conflict with). Happy to pin any of these repo-wide in a follow-up if you'd like, but didn't want to make that call unilaterally in a CI-unblocking PR.
- `macos-26` uses Xcode 26.6 under the **`native`** SwiftPM build system (Swift 6.3), the same module layout as the already-passing `macos-14`/`macos-15` legs — not `swiftbuild` (Xcode 27's new default, the layout #663 is about), so this PR doesn't touch that code path.
- Dropping `macos-13` removes the last Intel-macOS leg (`macos-14`/`-15`/`-26` are all arm64) and the only remaining Swift 5.8 toolchain in CI (the stated minimum in `Package.swift`/README) — Linux starts at 5.9. Flagging both in case either matters to you; happy to add back an older-toolchain leg if so.
- I'd posted on #663 assuming the runner's own Node/undici was the issue — that was wrong (the runner's Node is fine; the embedded Node in the brew binary is what's broken). I've corrected that there.

## Testing

- Unfiltered `swift test`: 165/165 passing, Xcode 26.6, with the 1.17.7 pin.
- `swift build -c release --product danger-swift`: succeeds, Xcode 26.6.
- `swift package update swift-snapshot-testing` under Xcode 26.6 resolves to 1.17.7, confirming the `Package.resolved` pin holds.
- YAML validated with `yaml.safe_load`.
- CI on this PR is the real end-to-end proof — will report back once it runs.
